### PR TITLE
build: speed up Distrobox starts after initialization

### DIFF
--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -1,13 +1,35 @@
 #!/usr/bin/env bash
 set -e
 
-PROJECT_ROOT="/tmp/gossip/build"
+# Parse command line arguments
+FORCE=NO
+while [[ $# -gt 0 ]]; do
+	case $1 in
+		-f|--force)
+			FORCE=YES
+			shift
+			;;
+		*)
+			echo "unknow argument \"$1\""
+			exit 1
+			;;
+	esac
+done
+
+# Skip script execution, if pjsip is already installed and
+# installation is not forced.
+if [ -f /opt/pjsip/include/pjsip.h ] && [ "$FORCE" == "NO" ]; then
+	echo "pjsip already installed."
+	exit 0
+fi
+
+PROJECT_ROOT="/tmp/gonnect/build"
 mkdir -p $PROJECT_ROOT
 
 TMPDIR=$(mktemp -d -p $PROJECT_ROOT)
 trap 'rm -rf -- "$TMPDIR"' EXIT
 
-cd $TMPDIR
+cd "$TMPDIR"
 git clone https://github.com/pjsip/pjproject.git && cd pjproject
 git submodule update --init --recursive
 git checkout 2.15.1


### PR DESCRIPTION
as the init_hooks were started on every container start and the initialization of the dev environment needs only done once.