### PR TITLE
fix(ui): default to non-ssl LDAP connections

### DIFF
--- a/resources/templates/sample.conf
+++ b/resources/templates/sample.conf
@@ -496,8 +496,8 @@ port=5061
 # port=443
 
 ## Whether to use SSL (https) or not (http).
-## (optional, default: true)
-# useSSL=true
+## (optional, default: false)
+# useSSL=false
 
 # # Whether a button to upgrade to a Jitsi Meet session should be displayed, if the counterpart is also a GOnnect client.
 # [jitsi]

--- a/sample.conf
+++ b/sample.conf
@@ -464,8 +464,8 @@
 #bindMethod="none"
 
 ## Whether to use SSL/TLS for the LDAP bind
-## (optional, default: true)
-# useSSL=true
+## (optional, default: false)
+# useSSL=false
 
 
 ## The dn used for LDAP simple bind

--- a/src/contacts/AddressBookManager.cpp
+++ b/src/contacts/AddressBookManager.cpp
@@ -189,9 +189,9 @@ bool AddressBookManager::processLDAPAddressBookConfigImpl(const QString &group,
         }
 
         LDAPAddressBookFeeder feeder(
-                settings.value("useSSL", false).toBool(), url, settings.value("base", "").toString(),
-                settings.value("filter", "").toString(), bindMethod,
-                settings.value("bindDn", "").toString(), password,
+                settings.value("useSSL", false).toBool(), url,
+                settings.value("base", "").toString(), settings.value("filter", "").toString(),
+                bindMethod, settings.value("bindDn", "").toString(), password,
                 settings.value("realm", "").toString(), settings.value("authcid", "").toString(),
                 settings.value("authzid", "").toString(), settings.value("caFile", "").toString(),
                 scriptableAttributes.isEmpty() ? QStringList()

--- a/src/contacts/AddressBookManager.cpp
+++ b/src/contacts/AddressBookManager.cpp
@@ -189,7 +189,7 @@ bool AddressBookManager::processLDAPAddressBookConfigImpl(const QString &group,
         }
 
         LDAPAddressBookFeeder feeder(
-                settings.value("useSSL", true).toBool(), url, settings.value("base", "").toString(),
+                settings.value("useSSL", false).toBool(), url, settings.value("base", "").toString(),
                 settings.value("filter", "").toString(), bindMethod,
                 settings.value("bindDn", "").toString(), password,
                 settings.value("realm", "").toString(), settings.value("authcid", "").toString(),
@@ -291,7 +291,7 @@ void AddressBookManager::processCardDAVAddressBookConfigImpl(const QString &grou
     }
     const auto controlHash = qHash(settingsHash);
 
-    const bool useSSL = settings.value("useSSL", true).toBool();
+    const bool useSSL = settings.value("useSSL", false).toBool();
 
     auto feeder = new CardDAVAddressBookFeeder(
             controlHash, settings.value("host", "").toString(),


### PR DESCRIPTION
Having SSL by default breaks backward compatibility with existing deployments and requires a configuration change.