### PR TITLE
fix: allow configuration of RTP port range

### DIFF
--- a/resources/templates/sample.conf
+++ b/resources/templates/sample.conf
@@ -206,6 +206,24 @@ registrarUri=sip:example.org
 ## default: false
 #lockCodecEnabled=false
 
+## UDP port number for RTP media to bind locally.
+## If the value is zero, the transport will be bound to any available port, and application can query the port by querying the transport info.
+## default: 4000
+#rtpPort=4000
+
+## Specify the RTP port range for socket binding, relative to the start port number specified in port.
+## Note that this setting is only applicable to media transport when the start port number is non zero. The port range needs to be a multiple
+## of 2, because we've alternating
+## Media transport is configurable via account setting, i.e: pjsua_acc_config.rtp_cfg, please check the media transport config docs for more info.
+## Available ports are in the range of [rtpPort, rtpPort + rtpPortRange].
+## default: 0
+#rtpPortRange=0
+
+## Specify whether to randomly pick the starting port number from  the range of [\a port, \a port + \a port_range]. This setting is
+## used only if both rtpPort and rtpPortRange are non-zero, and only
+## default: false
+#randomizeRtpPort=false
+
 ## UDP port number to bind locally. This setting MUST be specified even when default port is desired.
 ## If the value is zero, the transport will be bound to any available port, and application can query the port by querying the transport info.
 ## default: 5061
@@ -214,9 +232,14 @@ port=5061
 ## Specify the port range for socket binding, relative to the start port number specified in port.
 ## Note that this setting is only applicable to media transport when the start port number is non zero.
 ## Media transport is configurable via account setting, i.e: pjsua_acc_config.rtp_cfg, please check the media transport config docs for more info.
-## Available ports are in the range of [port, port + port_range].
+## Available ports are in the range of [port, port + portRange].
 ## default: 0
 #portRange=0
+
+## Specify whether to randomly pick the starting port number from the range of [port, port + portRange]. This setting is
+## used only if both port and portRange are non-zero, and only
+## default: false
+#randomizePort=false
 
 ## Certificate of Authority (CA) list file.
 ## default: ""
@@ -298,7 +321,7 @@ port=5061
 #iceAlwaysUpdate=true
 
 ## This option is used to overwrite the “sent-by” field of the Via header for outgoing messages with the same interface address as the one in the REGISTER request,
-## as long as the request uses the same transport instance as the previous REGISTER request. 
+## as long as the request uses the same transport instance as the previous REGISTER request.
 ## default: true
 #viaRewriteUse=true
 
@@ -412,13 +435,13 @@ port=5061
 ## The format follows this structure:
 ## frequency1, frequency2, [ interval1, interval2 ]+, loopIndex
 ##
-## frequency1 and frequency2 defines two frequencies in Hz, with 0 meaning "off".  
+## frequency1 and frequency2 defines two frequencies in Hz, with 0 meaning "off".
 ## Then, one or more tuples of intervals (in ms) follow, each describing how long frequency1 (first value) and frequency2 (second value) shall be played.
 ## Finally, the last value (loopIndex) indicates from which tuple index it shall loop. A loopIndex of "0" means that nothing is repeated.
 ##
-## Example: 
+## Example:
 ## 425,0,200,200,200,1000,200,200,200,1000,200,200,200,5000,4
-## 
+##
 ## will play the frequency 425 Hz followed by a pause (0 Hz) with these intervals:
 ##
 ## +---+-----------------+-----------------+
@@ -473,7 +496,7 @@ port=5061
 # useSSL=false
 
 ## The dn used for LDAP simple bind
-## This is the dn used for LDAP bind when the property "bindMethod" is set to "simple". It is ignored when "bindMethod" is "none" or not set. 
+## This is the dn used for LDAP bind when the property "bindMethod" is set to "simple". It is ignored when "bindMethod" is "none" or not set.
 ## When using with a SASL bind mechanism, the bindDn will be used, but the LDAP server will most likely ignore it.
 ## (required | ignored)
 #bindDn="cn=manager, o=university of michigan, c=us"
@@ -486,7 +509,7 @@ port=5061
 
 ## If the SIP environment the client is used in does support subscribing to buddy states (i.e. if a contact is available, busy, etc.), the phone number
 ## found for this LDAP attribute will be used for that subscription.
-## This is a performance optimization: when numbers saved under a specific attribute can and will never be subscriptable for SIP states (e.g. "mobile"), 
+## This is a performance optimization: when numbers saved under a specific attribute can and will never be subscriptable for SIP states (e.g. "mobile"),
 ## the client does not need to try. While not an excessive overhead, it might affect performance on slow systems and a large number of subscriptions.
 ## Multiple values must be comma-seperated, e.g. "telephoneNumber,mobile"
 ## (optional)

--- a/sample.conf
+++ b/sample.conf
@@ -201,6 +201,24 @@
 ## default: false
 #lockCodecEnabled=false
 
+## UDP port number for RTP media to bind locally.
+## If the value is zero, the transport will be bound to any available port, and application can query the port by querying the transport info.
+## default: 4000
+#rtpPort=4000
+
+## Specify the RTP port range for socket binding, relative to the start port number specified in port.
+## Note that this setting is only applicable to media transport when the start port number is non zero. The port range needs to be a multiple
+## of 2, because we've alternating
+## Media transport is configurable via account setting, i.e: pjsua_acc_config.rtp_cfg, please check the media transport config docs for more info.
+## Available ports are in the range of [rtpPort, rtpPort + rtpPortRange].
+## default: 0
+#rtpPortRange=0
+
+## Specify whether to randomly pick the starting port number from  the range of [\a port, \a port + \a port_range]. This setting is
+## used only if both rtpPort and rtpPortRange are non-zero, and only
+## default: false
+#randomizeRtpPort=false
+
 ## UDP port number to bind locally. This setting MUST be specified even when default port is desired.
 ## If the value is zero, the transport will be bound to any available port, and application can query the port by querying the transport info.
 ## default: 5061
@@ -210,6 +228,13 @@
 ## Note that this setting is only applicable to media transport when the start port number is non zero.
 ## Media transport is configurable via account setting, i.e: pjsua_acc_config.rtp_cfg, please check the media transport config docs for more info.
 ## Available ports are in the range of [port, port + port_range].
+## default: 0
+#portRange=0
+
+## Specify the port range for socket binding, relative to the start port number specified in port.
+## Note that this setting is only applicable to media transport when the start port number is non zero.
+## Media transport is configurable via account setting, i.e: pjsua_acc_config.rtp_cfg, please check the media transport config docs for more info.
+## Available ports are in the range of [port, port + portRange].
 ## default: 0
 #portRange=0
 

--- a/src/sip/SIPAccount.cpp
+++ b/src/sip/SIPAccount.cpp
@@ -146,6 +146,27 @@ bool SIPAccount::initialize()
     bool lockCodecEnabled = m_settings.value("lockCodecEnabled").toBool();
     m_accountConfig.mediaConfig.lockCodecEnabled = lockCodecEnabled;
 
+    int rtpPort = m_settings.value("rtpPort", 0).toInt(&ok);
+    if (!ok) {
+        qCCritical(lcSIPAccount) << "invalid value for 'rtpPort':" << rtpPort;
+        return false;
+    }
+    if (rtpPort != 0) {
+        m_accountConfig.mediaConfig.transportConfig.port = rtpPort;
+    }
+
+    int rtpPortRange = m_settings.value("rtpPortRange", 0).toInt(&ok);
+    if (!ok) {
+        qCCritical(lcSIPAccount) << "invalid value for 'rtpPortRange':" << rtpPort;
+        return false;
+    }
+    if (rtpPortRange != 0) {
+        m_accountConfig.mediaConfig.transportConfig.portRange = rtpPortRange;
+    }
+
+    m_accountConfig.mediaConfig.transportConfig.randomizePort =
+            m_settings.value("randomizeRtpPorts", false).toBool();
+
     // Transport
     int port = m_settings.value("port", 5061).toInt(&ok);
     if (!ok) {
@@ -154,12 +175,14 @@ bool SIPAccount::initialize()
     }
     m_transportConfig.port = port;
 
-    int portRange = m_settings.value("portRange", 0).toInt(&ok);
+    int portRange = m_settings.value("portRange", 10).toInt(&ok);
     if (!ok) {
         qCCritical(lcSIPAccount) << "invalid value for 'portRange':" << portRange;
         return false;
     }
     m_transportConfig.portRange = portRange;
+
+    m_transportConfig.randomizePort = m_settings.value("randomizePorts", false).toBool();
 
     QString caListFile = m_settings.value("caListFile").toString();
     if (!caListFile.isEmpty()) {


### PR DESCRIPTION
Some firewalls want it to be nailed down on specific ranges, so having a parameter for it is a plus.