### PR TITLE
fix: ignore timer for unvoluntary hook on via headset

### DIFF
--- a/src/GlobalInfo.cpp
+++ b/src/GlobalInfo.cpp
@@ -15,3 +15,16 @@ QString GlobalInfo::jitsiUrl()
     }
     return m_jitsiUrl;
 }
+
+bool GlobalInfo::isWorkaroundActive(const WorkaroundId id)
+{
+    if (m_workaroundActiveCache.contains(id)) {
+        return m_workaroundActiveCache.value(id);
+    }
+
+    ReadOnlyConfdSettings settings;
+    const auto idStr = GlobalInfo::workaroundIdToString(id);
+    const bool value = settings.value("workarounds/" + idStr, false).toBool();
+    m_workaroundActiveCache.insert(id, value);
+    return value;
+}

--- a/src/GlobalInfo.h
+++ b/src/GlobalInfo.h
@@ -6,8 +6,17 @@
 class GlobalInfo : public QObject
 {
     Q_OBJECT
+    Q_CLASSINFO("RegisterEnumClassesUnscoped", "false")
 
 public:
+    enum class WorkaroundId { GOW_001 };
+    Q_ENUM(WorkaroundId)
+
+    static QString workaroundIdToString(const WorkaroundId enumValue)
+    {
+        return QMetaEnum::fromType<WorkaroundId>().valueToKey(static_cast<int>(enumValue));
+    }
+
     static GlobalInfo &instance()
     {
         static GlobalInfo *_instance = nullptr;
@@ -19,10 +28,13 @@ public:
 
     Q_INVOKABLE QString jitsiUrl();
 
+    Q_INVOKABLE bool isWorkaroundActive(const WorkaroundId id);
+
 private:
     explicit GlobalInfo(QObject *parent = nullptr);
 
     bool m_isJitsiUrlInitialized = false;
+    QHash<WorkaroundId, bool> m_workaroundActiveCache;
     QString m_jitsiUrl;
 };
 

--- a/src/usb/HeadsetDevice.cpp
+++ b/src/usb/HeadsetDevice.cpp
@@ -4,6 +4,7 @@
 #include <QDateTime>
 #include <libusb.h>
 #include "HeadsetDevice.h"
+#include "GlobalInfo.h"
 
 Q_LOGGING_CATEGORY(lcHeadset, "gonnect.usb.headset")
 
@@ -184,7 +185,9 @@ void HeadsetDevice::setUsageInfos(const QHash<UsageId, UsageInfo> &infos)
 
 void HeadsetDevice::setBusyLine(bool flag)
 {
-    m_ignoreHookTimer.start();
+    if (GlobalInfo::instance().isWorkaroundActive(GlobalInfo::WorkaroundId::GOW_001)) {
+        m_ignoreHookTimer.start();
+    }
 
     if (!m_hidUsages.contains(UsageId::LED_OffHook)) {
         qCInfo(lcHeadset) << "Busy line is not supported by this device";
@@ -377,7 +380,8 @@ void HeadsetDevice::processEvents()
 
             // Hook switch
             if (m_hidUsages.contains(UsageId::Telephony_HookSwitch)) {
-                if (m_ignoreHookTimer.isActive()) {
+                if (GlobalInfo::instance().isWorkaroundActive(GlobalInfo::WorkaroundId::GOW_001)
+                    && m_ignoreHookTimer.isActive()) {
                     m_ignoreHookTimer.stop();
                 } else {
                     const auto &usage = m_hidUsages.value(UsageId::Telephony_HookSwitch);

--- a/src/usb/HeadsetDevice.h
+++ b/src/usb/HeadsetDevice.h
@@ -77,6 +77,7 @@ private:
 
     AppSettings m_appSettings;
     QTimer m_eventHandler;
+    QTimer m_ignoreHookTimer;
     QHash<UsageId, UsageInfo> m_hidUsages;
     QHash<UsageId, quint16> m_teamsUsageMapping;
 


### PR DESCRIPTION
Some headsets send a hook on flag immediately after receiving the busy line flag and will therefore terminate a call that has just been accepted via UI.

The fix introduces a ignore timer which will ignore the processing of the received flag in that situation.

Also introduces a new system to enable/disable optional workarounds. For the above one, add this to config:

```ini
[workarounds]
GOW_001=true
```