### PR TITLE
fix: read settings value for dark tray icon correctly

### DIFF
--- a/src/ui/components/SettingsPage.qml
+++ b/src/ui/components/SettingsPage.qml
@@ -248,11 +248,16 @@ Item {
                         property bool initialized: false
 
                         Component.onCompleted: () => {
-                            trayIconDark.checked = genericSettings.value('trayIconDark', false)
+                            let val = genericSettings.value('trayIconDark', false)
+                            if (typeof val === "string") {  // Value read from settings seems to be a string sometimes...
+                                val = val === "true"
+                            }
+
+                            trayIconDark.checked = val
                             trayIconDark.initialized = true
                         }
 
-                        onCheckedChanged: () => {
+                        onToggled: () => {
                             if (trayIconDark.initialized) {
                                 genericSettings.setValue('trayIconDark', trayIconDark.checked)
                                 ViewHelper.resetTrayIcon()


### PR DESCRIPTION
The value is - for some unkown reason - sometimes read as a string and not as a bool value. This fix converts the value accordingly.