### PR TITLE
fix: segfault happend in certain hold states

### DIFF
--- a/src/GlobalCallState.cpp
+++ b/src/GlobalCallState.cpp
@@ -152,9 +152,12 @@ void GlobalCallState::triggerHold()
     }
 
     // n calls, 1 active - hold active call, unhold next
-    if (callsNotOnHold.size()) {
+    if (!callsNotOnHold.isEmpty()) {
         (*activeCalls.cbegin())->toggleHold();
-        (*callsOnHold.cbegin())->toggleHold();
+
+        if (!callsOnHold.isEmpty()) {
+            (*callsOnHold.cbegin())->toggleHold();
+        }
         return;
     }
 


### PR DESCRIPTION
When a Jitsi Meet conference and a SIP call are active simultaniously, triggering the hold button in the conference caused a segfault due to dereferencing a nullptr.