### PR TITLE
fix: validate preferred identity field on input

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -203,6 +203,7 @@ qt_add_qml_module(gonnect
         ui/components/controls/Switch.qml
         ui/components/controls/TabBar.qml
         ui/components/controls/TabButton.qml
+        ui/components/controls/TextField.qml
 
         ui/components/dialogs/CredentialsDialog.qml
         ui/components/dialogs/BaseDialog.qml
@@ -377,6 +378,8 @@ qt_add_qml_module(gonnect
         sip/SIPUserAgentConfig.cpp
         sip/PreferredIdentity.h
         sip/PreferredIdentity.cpp
+        sip/PreferredIdentityValidator.h
+        sip/PreferredIdentityValidator.cpp
         sip/Ringer.h
         sip/Ringer.cpp
         sip/RingTone.h

--- a/src/contacts/Contact.cpp
+++ b/src/contacts/Contact.cpp
@@ -231,7 +231,7 @@ void Contact::updateSipStatusSubscriptable()
 
 bool Contact::isNumberValid(const QString &number) const
 {
-    return !number.isEmpty() && number != "+492932916";
+    return !number.isEmpty();
 }
 
 QList<Contact::PhoneNumber> Contact::phoneNumbers() const

--- a/src/sip/PreferredIdentity.cpp
+++ b/src/sip/PreferredIdentity.cpp
@@ -1,7 +1,7 @@
 #include <QLoggingCategory>
-#include <QRegularExpression>
 #include "SIPManager.h"
 #include "PreferredIdentity.h"
+#include "PreferredIdentityValidator.h"
 
 Q_LOGGING_CATEGORY(lcSIPIdentity, "gonnect.sip.identity")
 
@@ -89,11 +89,7 @@ void PreferredIdentity::setAutomatic(bool flag)
 
 void PreferredIdentity::validate()
 {
-    static const QRegularExpression numberMatch("^\\+[0-9]+$");
-    static const QRegularExpression mulitNumberMatch("^(\\+[0-9]+)(,\\+[0-9]+)*$");
-
-    const bool isValid = !m_displayName.isEmpty() && numberMatch.match(m_identity).hasMatch()
-            && (m_prefix.isEmpty() || mulitNumberMatch.match(m_prefix).hasMatch());
+    const bool isValid = PreferredIdentityValidator::instance().isValid(*this);
 
     if (isValid != m_isValid) {
         m_isValid = isValid;

--- a/src/sip/PreferredIdentityValidator.cpp
+++ b/src/sip/PreferredIdentityValidator.cpp
@@ -24,6 +24,6 @@ bool PreferredIdentityValidator::isIdentityNumberValid(const QString &identityNu
 
 bool PreferredIdentityValidator::isPrefixValid(const QString &prefix) const
 {
-    static const QRegularExpression mulitNumberMatch("^(\\+[0-9]+)(,\\+[0-9]+)*$");
-    return prefix.isEmpty() || mulitNumberMatch.match(prefix).hasMatch();
+    Q_UNUSED(prefix)
+    return true;
 }

--- a/src/sip/PreferredIdentityValidator.cpp
+++ b/src/sip/PreferredIdentityValidator.cpp
@@ -1,0 +1,29 @@
+#include "PreferredIdentityValidator.h"
+
+#include <QRegularExpression>
+
+PreferredIdentityValidator::PreferredIdentityValidator(QObject *parent) : QObject{ parent } { }
+
+bool PreferredIdentityValidator::isValid(const PreferredIdentity &preferredIdentity) const
+{
+    return isDisplayNameValid(preferredIdentity.displayName())
+            && isIdentityNumberValid(preferredIdentity.identity())
+            && isPrefixValid(preferredIdentity.prefix());
+}
+
+bool PreferredIdentityValidator::isDisplayNameValid(const QString &displayName) const
+{
+    return !displayName.isEmpty();
+}
+
+bool PreferredIdentityValidator::isIdentityNumberValid(const QString &identityNumber) const
+{
+    static const QRegularExpression numberMatch("^\\+[0-9]+$");
+    return numberMatch.match(identityNumber).hasMatch();
+}
+
+bool PreferredIdentityValidator::isPrefixValid(const QString &prefix) const
+{
+    static const QRegularExpression mulitNumberMatch("^(\\+[0-9]+)(,\\+[0-9]+)*$");
+    return prefix.isEmpty() || mulitNumberMatch.match(prefix).hasMatch();
+}

--- a/src/sip/PreferredIdentityValidator.h
+++ b/src/sip/PreferredIdentityValidator.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <QObject>
+#include <QQmlEngine>
+
+#include "PreferredIdentity.h"
+
+class PreferredIdentityValidator : public QObject
+{
+    Q_OBJECT
+
+public:
+    static PreferredIdentityValidator &instance()
+    {
+        static PreferredIdentityValidator *_instance = nullptr;
+        if (!_instance) {
+            _instance = new PreferredIdentityValidator;
+        }
+        return *_instance;
+    }
+
+    bool isValid(const PreferredIdentity &preferredIdentity) const;
+
+    Q_INVOKABLE bool isDisplayNameValid(const QString &displayName) const;
+    Q_INVOKABLE bool isIdentityNumberValid(const QString &identityNumber) const;
+    Q_INVOKABLE bool isPrefixValid(const QString &prefix) const;
+
+private:
+    explicit PreferredIdentityValidator(QObject *parent = nullptr);
+};
+
+class PreferredIdentityValidatorWrapper
+{
+    Q_GADGET
+    QML_FOREIGN(PreferredIdentityValidator)
+    QML_NAMED_ELEMENT(PreferredIdentityValidator)
+    QML_SINGLETON
+
+public:
+    static PreferredIdentityValidator *create(QQmlEngine *, QJSEngine *)
+    {
+        return &PreferredIdentityValidator::instance();
+    }
+
+private:
+    PreferredIdentityValidatorWrapper() = default;
+};

--- a/src/sip/SIPManager.cpp
+++ b/src/sip/SIPManager.cpp
@@ -175,7 +175,7 @@ PreferredIdentity *SIPManager::addEmptyPreferredIdentity()
     auto identity =
             new PreferredIdentity(this, QString::asprintf("preferred_identity_%u", maxId + 1));
     identity->setDisplayName(tr("New Identity"));
-    identity->setIdentity("+4929329160");
+    identity->setIdentity("+49221123456789");
     identity->setPrefix("");
     identity->setEnabled(true);
     identity->setAutomatic(true);

--- a/src/ui/PreferredIdentityEditWindow.qml
+++ b/src/ui/PreferredIdentityEditWindow.qml
@@ -102,6 +102,7 @@ BaseWindow {
                 id: displayNameTextField
                 placeholderText: qsTr("Name")
                 text: internal.originalDisplayName
+                isValid: PreferredIdentityValidator.isDisplayNameValid(displayNameTextField.text)
                 anchors {
                     left: parent.left
                     right: parent.right
@@ -112,6 +113,7 @@ BaseWindow {
                 id: prefixTextField
                 placeholderText: qsTr("Prefix")
                 text: internal.originalPrefix
+                isValid: PreferredIdentityValidator.isPrefixValid(prefixTextField.text)
                 anchors {
                     left: parent.left
                     right: parent.right
@@ -122,6 +124,7 @@ BaseWindow {
                 id: identityTextField
                 placeholderText: qsTr("Identity")
                 text: internal.originalIdentity
+                isValid: PreferredIdentityValidator.isIdentityNumberValid(identityTextField.text)
                 anchors {
                     left: parent.left
                     right: parent.right
@@ -182,10 +185,12 @@ BaseWindow {
         Button {
             id: saveButton
             text: qsTr("Save")
-            enabled: internal.modified && control.preferredIdentity?.isValid
             highlighted: true
             icon.source: Icons.documentSave
-
+            enabled: internal.modified
+                     && displayNameTextField.isValid
+                     && prefixTextField.isValid
+                     && identityTextField.isValid
             anchors {
                 bottom: parent.bottom
                 bottomMargin: 5

--- a/src/ui/components/ChatSideBar.qml
+++ b/src/ui/components/ChatSideBar.qml
@@ -123,7 +123,7 @@ Item {
                 Label {
                     id: infoLabel
                     y: 20
-                    font.pixelSize: 10
+                    font.pixelSize: 14
                     textFormat: Text.StyledText
                     color: Theme.secondaryTextColor
                     text: delg.nickName ? `${delg.nickName}, ${delg.timeFormatted}` : delg.timeFormatted

--- a/src/ui/components/controls/TextField.qml
+++ b/src/ui/components/controls/TextField.qml
@@ -1,0 +1,83 @@
+import QtQuick
+import QtQuick.Templates as T
+import QtQuick.Controls.impl
+import QtQuick.Controls.Material
+import QtQuick.Controls.Material.impl
+import base
+
+T.TextField {
+    id: control
+
+    property bool isValid: true
+
+    implicitWidth: implicitBackgroundWidth + leftInset + rightInset
+                   || Math.max(contentWidth, placeholder.implicitWidth) + leftPadding + rightPadding
+    implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
+                             contentHeight + topPadding + bottomPadding)
+
+    // If we're clipped, set topInset to half the height of the placeholder text to avoid it being clipped.
+    topInset: clip ? placeholder.largestHeight / 2 : 0
+
+    leftPadding: Material.textFieldHorizontalPadding
+    rightPadding: Material.textFieldHorizontalPadding
+    // Need to account for the placeholder text when it's sitting on top.
+    topPadding: Material.containerStyle === Material.Filled
+        ? placeholderText.length > 0 && (activeFocus || length > 0)
+            ? Material.textFieldVerticalPadding + placeholder.largestHeight
+            : Material.textFieldVerticalPadding
+        // Account for any topInset (used to avoid floating placeholder text being clipped),
+        // otherwise the text will be too close to the background.
+        : Material.textFieldVerticalPadding + topInset
+    bottomPadding: Material.textFieldVerticalPadding
+
+    color: enabled ? Material.foreground : Material.hintTextColor
+    selectionColor: Material.accentColor
+    selectedTextColor: Material.primaryHighlightedTextColor
+    placeholderTextColor: enabled && activeFocus ? Material.accentColor : Material.hintTextColor
+    verticalAlignment: TextInput.AlignVCenter
+
+    Material.containerStyle: Material.Outlined
+
+    cursorDelegate: CursorDelegate { }
+
+    FloatingPlaceholderText {
+        id: placeholder
+        width: control.width - (control.leftPadding + control.rightPadding)
+        text: control.placeholderText
+        font: control.font
+        color: control.placeholderTextColor
+        elide: Text.ElideRight
+        renderType: control.renderType
+
+        filled: control.Material.containerStyle === Material.Filled
+        verticalPadding: control.Material.textFieldVerticalPadding
+        controlHasActiveFocus: control.activeFocus
+        controlHasText: control.length > 0
+        controlImplicitBackgroundHeight: control.implicitBackgroundHeight
+        controlHeight: control.height
+        leftPadding: control.leftPadding
+        floatingLeftPadding: control.Material.textFieldHorizontalPadding
+    }
+
+    background: MaterialTextContainer {
+        implicitWidth: 120
+        implicitHeight: control.Material.textFieldHeight
+
+        filled: control.Material.containerStyle === Material.Filled
+        fillColor: control.Material.textFieldFilledContainerColor
+        outlineColor: control.isValid
+                      ? ((enabled && control.hovered)
+                         ? control.Material.primaryTextColor
+                         : control.Material.hintTextColor)
+                      : Theme.redColor
+        focusedOutlineColor: control.isValid ? control.Material.accentColor : Theme.redColor
+        // When the control's size is set larger than its implicit size, use whatever size is smaller
+        // so that the gap isn't too big.
+        placeholderTextWidth: Math.min(placeholder.width, placeholder.implicitWidth) * placeholder.scale
+        placeholderTextHAlign: control.effectiveHorizontalAlignment
+        controlHasActiveFocus: control.activeFocus
+        controlHasText: control.length > 0
+        placeholderHasText: placeholder.text.length > 0
+        horizontalPadding: control.Material.textFieldHorizontalPadding
+    }
+}


### PR DESCRIPTION
The preferred identity object has a validation. Invalid identities will not be shown in the UI and not be selected when the identity is set to `auto`. 

Since this validation only happened after the identity has been saved, it was possible to create invalid ones. 

This PR has the validation refactored and used by the edit widget for identities.