### PR TITLE
fix: avoid parallel calls for date event queue processor

### DIFF
--- a/src/calendar/DateEventFeederManager.h
+++ b/src/calendar/DateEventFeederManager.h
@@ -2,6 +2,7 @@
 
 #include <QObject>
 #include <QHash>
+#include <QMutex>
 
 class IDateEventFeeder;
 
@@ -26,6 +27,8 @@ public:
 
 private:
     explicit DateEventFeederManager(QObject *parent = nullptr);
+
+    QMutex m_queueMutex;
 
     void processQueue();
     void setupReconnectSignal();


### PR DESCRIPTION
This is the `DateEventFeederManager`-equivalent fix for #149. 