### PR TITLE
fix: re-trigger event notifications for updated events

### DIFF
--- a/src/calendar/DateEvent.cpp
+++ b/src/calendar/DateEvent.cpp
@@ -1,5 +1,7 @@
 #include "DateEvent.h"
 
+#include<QHash>
+
 DateEvent::DateEvent(const QString &id, const QString &source, const QDateTime &start,
                      const QDateTime &end, const QString &summary, const QString &roomName,
                      bool isConfirmed, QObject *parent)
@@ -47,6 +49,17 @@ void DateEvent::setRoomName(const QString &roomName)
 void DateEvent::setIsConfirmed(bool isConfirmed)
 {
     m_isConfirmed = isConfirmed;
+}
+
+size_t DateEvent::getHash()
+{
+    size_t sum = 0;
+    sum ^= qHash(m_id);
+    sum ^= qHash(m_start);
+    sum ^= qHash(m_end);
+    sum ^= qHash(m_summary);
+    sum ^= qHash(m_roomName);
+    return sum;
 }
 
 QDebug operator<<(QDebug debug, const DateEvent &dateEvent)

--- a/src/calendar/DateEvent.h
+++ b/src/calendar/DateEvent.h
@@ -28,6 +28,8 @@ public:
     void setRoomName(const QString &roomName);
     void setIsConfirmed(bool isConfirmed);
 
+    size_t getHash();
+
 private:
     QString m_id;
     QString m_source;

--- a/src/calendar/DateEventManager.h
+++ b/src/calendar/DateEventManager.h
@@ -51,14 +51,14 @@ private slots:
 private:
     explicit DateEventManager(QObject *parent = nullptr);
 
-    DateEvent *findDateEventById(const QString &id) const;
+    DateEvent *findDateEventByHash(const size_t &eventHash) const;
     bool isTooOld(const DateEvent &dateEvent) const;
     bool isOver(const DateEvent &dateEvent) const;
 
     QString m_jitsiUrl;
     QList<DateEvent *> m_dateEvents;
-    QHash<QString, QString> m_notificationIds;
-    QSet<QString> m_alreadyNotifiedDates;
+    QHash<size_t, QString> m_notificationIds;
+    QSet<size_t> m_alreadyNotifiedDates;
     QTimer m_minuteTimer;
     QTime m_lastCheckedTime;
     QDate m_lastCheckedDate;


### PR DESCRIPTION
`DateEvents` that have received updates may now trigger yet another notification even if a notification has been triggered before.