### PR TITLE
fix: honour tray icon activation reasons

### DIFF
--- a/src/ui/SystemTrayMenu.cpp
+++ b/src/ui/SystemTrayMenu.cpp
@@ -26,6 +26,14 @@ SystemTrayMenu::SystemTrayMenu(QObject *parent) : QObject{ parent }
     m_trayIcon->show();
     resetTrayIcon();
 
+    connect(m_trayIcon, &QSystemTrayIcon::activated, this, [](QSystemTrayIcon::ActivationReason reason){
+        if (reason == QSystemTrayIcon::DoubleClick ||
+            reason == QSystemTrayIcon::MiddleClick ||
+            reason == QSystemTrayIcon::Trigger) {
+            emit ViewHelper::instance().activateSearch();
+        }
+    });
+
     updateMenu();
 
     m_ringTimer.setInterval(750ms);

--- a/src/ui/SystemTrayMenu.cpp
+++ b/src/ui/SystemTrayMenu.cpp
@@ -26,13 +26,13 @@ SystemTrayMenu::SystemTrayMenu(QObject *parent) : QObject{ parent }
     m_trayIcon->show();
     resetTrayIcon();
 
-    connect(m_trayIcon, &QSystemTrayIcon::activated, this, [](QSystemTrayIcon::ActivationReason reason){
-        if (reason == QSystemTrayIcon::DoubleClick ||
-            reason == QSystemTrayIcon::MiddleClick ||
-            reason == QSystemTrayIcon::Trigger) {
-            emit ViewHelper::instance().activateSearch();
-        }
-    });
+    connect(m_trayIcon, &QSystemTrayIcon::activated, this,
+            [](QSystemTrayIcon::ActivationReason reason) {
+                if (reason == QSystemTrayIcon::DoubleClick || reason == QSystemTrayIcon::MiddleClick
+                    || reason == QSystemTrayIcon::Trigger) {
+                    emit ViewHelper::instance().activateSearch();
+                }
+            });
 
     updateMenu();
 

--- a/src/ui/Theme.cpp
+++ b/src/ui/Theme.cpp
@@ -35,7 +35,7 @@ bool Theme::useOwnDecoration()
 
         AppSettings settings;
         const auto settingsVal =
-                settings.value("generic/useOwnWindowDecoration", "true").toString();
+                settings.value("generic/useOwnWindowDecoration", "auto").toString();
 
         if (settingsVal == "auto") {
             const auto desktop =


### PR DESCRIPTION
This change moves back to "auto" for system side window decorations, which means that only GNOME receives a custom window decoration by default. All others need to activate it manually if they want to in the settings.

Secondly, I've re-activated dealing with the "activation reason" for the tray menu. KDE users can open GOnnect with a single left/middle click now, additionally that works over the platforms with a double click.