### PR TITLE
fix(ui): change to conference page on video upgrade

### DIFF
--- a/src/GlobalCallState.cpp
+++ b/src/GlobalCallState.cpp
@@ -65,12 +65,15 @@ bool GlobalCallState::registerCallStateObject(ICallState *callStateObject)
 
         connect(callStateObject, &ICallState::callStateChanged, this,
                 [this, callStateObject](ICallState::States newState, ICallState::States oldState) {
-                    const auto CallActive = ICallState::State::CallActive;
+                    using State = ICallState::State;
 
-                    if (!(oldState & CallActive) && (newState & CallActive)) {
-                        m_lastCallThatBecameActive = callStateObject;
-                    } else if ((oldState & CallActive) && !(newState & CallActive)) {
-                        m_lastCallThatBecameActive = nullptr;
+                    if (!(oldState & State::Migrating)) {
+                        if (!(oldState & State::CallActive) && (newState & State::CallActive)) {
+                            m_lastCallThatBecameActive = callStateObject;
+                        } else if ((oldState & State::CallActive)
+                                   && !(newState & State::CallActive)) {
+                            m_lastCallThatBecameActive = nullptr;
+                        }
                     }
                 });
 


### PR DESCRIPTION
When upgrading a SIP call to a Jitsi Meet conference, the call page was still active. This fix changes that by not respecting migrating calls when selecting the page to show.