### PR TITLE
fix(ui): do not show multiple password dialogs

### DIFF
--- a/src/Main.qml
+++ b/src/Main.qml
@@ -37,6 +37,7 @@ Item {
         target: ViewHelper
 
         property EmergencyCallIncomingWindow emergencyWindow: null
+        property var passwordDialogs: ({})
 
         function onActivateSearch() {
             gonnectWindow.ensureVisible()
@@ -74,8 +75,17 @@ Item {
         }
 
         function onPasswordRequested(id : string, host : string) {
-            const dialog = DialogFactory.createDialog("CredentialsDialog.qml", { text: qsTr("Please enter the password for %1:").arg(host) })
-            dialog.onPasswordAccepted.connect(pw => ViewHelper.respondPassword(id, pw))
+            const existingDialog = viewHelperConnections.passwordDialogs
+
+            if (!existingDialog) {
+                const dialog = DialogFactory.createDialog("CredentialsDialog.qml", { text: qsTr("Please enter the password for %1:").arg(host) })
+                dialog.onPasswordAccepted.connect(pw => ViewHelper.respondPassword(id, pw))
+
+                viewHelperConnections.passwordDialogs[id] = dialog
+                dialog.Component.destruction.connect(() => delete viewHelperConnections.passwordDialogs[id])
+            } else {
+                existingDialog.show()
+            }
         }
     }
 


### PR DESCRIPTION
When a user does not enter a password in a dialog that requests it, it can happen that multiple such dialogs are shown.