### PR TITLE
fix: use promise/future for async date event processing (eds) to avoid ooo conditions

### DIFF
--- a/src/calendar/DateEventFeederManager.cpp
+++ b/src/calendar/DateEventFeederManager.cpp
@@ -138,7 +138,7 @@ void DateEventFeederManager::processQueue()
                 }
             }
 
-            feeder->process();
+            feeder->init();
             it.remove();
         }
     }

--- a/src/calendar/IDateEventFeeder.h
+++ b/src/calendar/IDateEventFeeder.h
@@ -6,6 +6,6 @@ class IDateEventFeeder
 {
 
 public:
-    virtual void process() = 0;
+    virtual void init() = 0;
     virtual QUrl networkCheckURL() const { return QUrl(); }
 };

--- a/src/calendar/akonadi/AkonadiEventFeeder.cpp
+++ b/src/calendar/akonadi/AkonadiEventFeeder.cpp
@@ -6,9 +6,13 @@
 
 Q_LOGGING_CATEGORY(lcAkonadiEventFeeder, "gonnect.app.dateevents.feeder.akonadi")
 
-AkonadiEventFeeder::AkonadiEventFeeder(QObject *parent)
+AkonadiEventFeeder::AkonadiEventFeeder(QObject *parent, const QString &source,
+                                       const QDateTime &timeRangeStart,
+                                       const QDateTime &timeRangeEnd)
     : QObject(parent),
-      m_session(new Akonadi::Session("GOnnect::CalendarSession")),
+      m_source(source),
+      m_timeRangeStart(timeRangeStart),
+      m_timeRangeEnd(timeRangeEnd) m_session(new Akonadi::Session("GOnnect::CalendarSession")),
       m_monitor(new Akonadi::Monitor(parent))
 {
 }
@@ -19,15 +23,8 @@ AkonadiEventFeeder::~AkonadiEventFeeder()
     delete m_session;
 }
 
-void AkonadiEventFeeder::init(const QString &settingsGroupId, const QString &source,
-                              const QDateTime &timeRangeStart, const QDateTime &timeRangeEnd)
+void AkonadiEventFeeder::init()
 {
-    Q_UNUSED(settingsGroupId)
-
-    m_source = source;
-    m_timeRangeStart = timeRangeStart;
-    m_timeRangeEnd = timeRangeEnd;
-
     Akonadi::ItemFetchScope scope;
     scope.fetchFullPayload(true);
 
@@ -63,6 +60,8 @@ void AkonadiEventFeeder::init(const QString &settingsGroupId, const QString &sou
 
         process();
     });
+
+    process();
 }
 
 void AkonadiEventFeeder::process()

--- a/src/calendar/akonadi/AkonadiEventFeeder.h
+++ b/src/calendar/akonadi/AkonadiEventFeeder.h
@@ -24,14 +24,16 @@ class AkonadiEventFeeder : public QObject, public IDateEventFeeder
     Q_OBJECT
 
 public:
-    explicit AkonadiEventFeeder(QObject *parent = nullptr);
+    explicit AkonadiEventFeeder(QObject *parent = nullptr, const QString &source = "",
+                                const QDateTime &timeRangeStart = QDateTime(),
+                                const QDateTime &timeRangeEnd = QDateTime());
+
     ~AkonadiEventFeeder();
 
-    void init(const QString &settingsGroupId, const QString &source,
-              const QDateTime &timeRangeStart, const QDateTime &timeRangeEnd);
-
-    virtual void process() override;
+    virtual void init() override;
     virtual QUrl networkCheckURL() const override { return QUrl(); };
+
+    void process();
 
 private slots:
     void processCollections(KJob *job);

--- a/src/calendar/akonadi/AkonadiEventFeederFactory.cpp
+++ b/src/calendar/akonadi/AkonadiEventFeederFactory.cpp
@@ -32,9 +32,5 @@ IDateEventFeeder *AkonadiEventFeederFactory::createFeeder(
     ReadOnlyConfdSettings settings;
     settings.beginGroup(settingsGroup);
 
-    auto feeder = new AkonadiEventFeeder(feederManager);
-
-    feeder->init(settingsGroup, name(), timeRangeStart, timeRangeEnd);
-
-    return feeder;
+    return new AkonadiEventFeeder(feederManager, name(), timeRangeStart, timeRangeEnd);
 }

--- a/src/calendar/caldav/CalDAVEventFeeder.h
+++ b/src/calendar/caldav/CalDAVEventFeeder.h
@@ -16,15 +16,19 @@ class CalDAVEventFeeder : public QObject, public IDateEventFeeder
     Q_OBJECT
 
 public:
-    explicit CalDAVEventFeeder(QObject *parent = nullptr);
+    explicit CalDAVEventFeeder(QObject *parent = nullptr, const QString &settingsGroupId = "",
+                               const QString &source = "", const QString &host = "",
+                               const QString &path = "", const QString &user = "", int port = 0,
+                               bool useSSL = true, int interval = 300000,
+                               const QDateTime &timeRangeStart = QDateTime(),
+                               const QDateTime &timeRangeEnd = QDateTime());
+
     ~CalDAVEventFeeder();
 
-    void init(const QString &settingsGroupId, const QString &source, const QString &host,
-              const QString &path, const QString &user, int port, bool useSSL, int interval,
-              const QDateTime &timeRangeStart, const QDateTime &timeRangeEnd);
-
-    virtual void process() override;
+    virtual void init() override;
     virtual QUrl networkCheckURL() const override { return m_url; };
+
+    void process();
 
 private slots:
     void onError(QString error) const;
@@ -38,18 +42,17 @@ private:
 
     QList<size_t> m_checksums;
 
-    QString m_source;
-    QDateTime m_timeRangeStart;
-    QDateTime m_timeRangeEnd;
-
-    QUrl m_url;
     QString m_settingsGroupId;
+    QString m_source;
     QString m_host;
     QString m_path;
     QString m_user;
-    int m_port = 0;
-    bool m_useSSL = true;
-    int m_interval = 300000;
+    int m_port;
+    bool m_useSSL;
+    int m_interval;
+    QDateTime m_timeRangeStart;
+    QDateTime m_timeRangeEnd;
+    QUrl m_url;
 
     QTimer m_calendarRefreshTimer;
 

--- a/src/calendar/eds/EDSEventFeederFactory.cpp
+++ b/src/calendar/eds/EDSEventFeederFactory.cpp
@@ -33,9 +33,5 @@ IDateEventFeeder *EDSEventFeederFactory::createFeeder(const QString &settingsGro
     ReadOnlyConfdSettings settings;
     settings.beginGroup(settingsGroup);
 
-    auto feeder = new EDSEventFeeder(feederManager);
-
-    feeder->init(settingsGroup, name(), timeRangeStart, timeRangeEnd);
-
-    return feeder;
+    return new EDSEventFeeder(feederManager, name(), timeRangeStart, timeRangeEnd);
 }

--- a/src/contacts/eds/EDSAddressBookFeeder.h
+++ b/src/contacts/eds/EDSAddressBookFeeder.h
@@ -5,6 +5,10 @@
 #include <glib.h>
 
 #include <QObject>
+#include <QFuture>
+#include <QFutureWatcher>
+#include <QPromise>
+
 #include "IAddressBookFeeder.h"
 
 class AddressBookManager;
@@ -24,8 +28,11 @@ private:
     QString getFieldMerge(EContact *contact, EContactField pId, EContactField sId);
     void addAvatar(QString id, EContact *contact, QDateTime changed);
 
-    bool init();
+    void init();
     void feedAddressBook();
+
+    static void onEbookClientConnected(GObject *source_object, GAsyncResult *result,
+                                       gpointer user_data);
 
     void connectContactSignals(EBookClientView *view);
 
@@ -39,6 +46,11 @@ private:
 
     static void onViewCreated(GObject *source_object, GAsyncResult *result, gpointer user_data);
 
+    static void onClientContactsRequested(GObject *source_object, GAsyncResult *result,
+                                          gpointer user_data);
+
+    void processContacts(QString clientInfo, GSList *contacts);
+
     QString m_group;
 
     ESourceRegistry *m_registry = nullptr;
@@ -46,4 +58,10 @@ private:
     gchar *m_searchExpr = nullptr;
     QList<EBookClient *> m_clients;
     QList<EBookClientView *> m_clientViews;
+
+    int m_sourceCount = 0;
+    std::atomic<int> m_clientCount = 0;
+    QPromise<void> *m_sourcePromise = nullptr;
+    QFuture<void> m_sourceFuture;
+    QFutureWatcher<void> *m_futureWatcher = nullptr;
 };


### PR DESCRIPTION
Due to the asynchronous nature of EDS, there was a definite possibility that `AddressBook` and `DateEvent` EDS feeders prematurely called `process()` methods while the required callbacks inside of the `init()` methods had not yet finished (OOO/out -of-order execution).

To address this issue, the `init()` methods now feature a `QFuture/QPromise` system that triggers once all clients have been successfully connected to. If this fails, the entire process will cleanly abort after a 5 second timeout.

Additionally, the EDS client connection mechanism used in the `AddressBook` plugin now uses async methods as well to avoid main thread blockage.
