### PR TITLE
fix: display past recurrent event instances that have been updated

### DIFF
--- a/src/calendar/DateEventManager.cpp
+++ b/src/calendar/DateEventManager.cpp
@@ -183,6 +183,21 @@ void DateEventManager::removeDateEventsBySource(const QString &source)
     }
 }
 
+bool DateEventManager::isAddedDateEvent(const QString &id)
+{
+    // Useful to check if an event instance is a past recurrence,
+    // but has been moved into the future
+    QMutableListIterator it(m_dateEvents);
+    while (it.hasNext()) {
+        const auto event = it.next();
+        if (event && event->id() == id) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 DateEvent *DateEventManager::currentDateEventByRoomName(const QString &roomName) const
 {
     if (roomName.isEmpty()) {

--- a/src/calendar/DateEventManager.h
+++ b/src/calendar/DateEventManager.h
@@ -40,6 +40,8 @@ public:
 
     const QList<DateEvent *> &dateEvents() const { return m_dateEvents; }
 
+    bool isAddedDateEvent(const QString &id);
+
     /// Find the DateEvent by the given room name that is currently taking place or nullptr
     DateEvent *currentDateEventByRoomName(const QString &roomName) const;
 

--- a/src/calendar/akonadi/AkonadiEventFeeder.cpp
+++ b/src/calendar/akonadi/AkonadiEventFeeder.cpp
@@ -171,7 +171,7 @@ void AkonadiEventFeeder::processCollections(KJob *job)
                             }
                         } else {
                             // Non-recurrent event or update of a recurrent event instance
-                            if (isUpdatedRecurrence) {
+                            if (isUpdatedRecurrence && manager.isAddedDateEvent(id)) {
                                 manager.modifyDateEvent(id, m_source, start, end, summary, location,
                                                         true);
                             } else {

--- a/src/calendar/caldav/CalDAVEventFeeder.cpp
+++ b/src/calendar/caldav/CalDAVEventFeeder.cpp
@@ -182,7 +182,7 @@ void CalDAVEventFeeder::processResponse(const QByteArray &data)
                 }
             } else {
                 // Non-recurrent event or update of a recurrent event instance
-                if (isUpdatedRecurrence) {
+                if (isUpdatedRecurrence && manager.isAddedDateEvent(id)) {
                     manager.modifyDateEvent(id, m_config.source, start, end, summary, location,
                                             true);
                 } else {

--- a/src/calendar/eds/EDSEventFeeder.cpp
+++ b/src/calendar/eds/EDSEventFeeder.cpp
@@ -423,7 +423,7 @@ void EDSEventFeeder::processEvents(QString clientName, QString clientUid, GSList
                 }
             } else {
                 // Non-recurrent event or update of a recurrent event instance
-                if (isUpdatedRecurrence) {
+                if (isUpdatedRecurrence && manager.isAddedDateEvent(id)) {
                     manager.modifyDateEvent(id, concreteSource, start, end, summary, location,
                                             true);
                 } else {


### PR DESCRIPTION
Recurrent event instances are added by iterating through the origin event series and adding all instances that fall into the selected time range of interest (now + 3 days).

If a recurrent event instance is in the past but has been updated to fall into our time range, it'll now be displayed properly.