### PR TITLE
fix: added mutex for addressbook operations

### DIFF
--- a/src/contacts/AddressBook.cpp
+++ b/src/contacts/AddressBook.cpp
@@ -60,6 +60,9 @@ Contact *AddressBook::addContact(const QString &dn, const QString &sourceUid,
     const auto hid = hashifyCn(dn);
 
     bool newContactCreated = false;
+
+    QMutexLocker lock(&m_feederMutex);
+
     Contact *contact = m_contacts.value(hid, nullptr);
     if (!contact) {
         newContactCreated = true;
@@ -87,6 +90,8 @@ Contact *AddressBook::addContact(const QString &dn, const QString &sourceUid,
 
 void AddressBook::addContact(Contact *contact)
 {
+    QMutexLocker lock(&m_feederMutex);
+
     if (contact != nullptr && !m_contacts.contains(contact->id())) {
         contact->setParent(this);
         m_contacts.insert(contact->id(), contact);
@@ -102,6 +107,9 @@ Contact *AddressBook::modifyContact(const QString &dn, const QString &sourceUid,
                                     const QList<Contact::PhoneNumber> &phoneNumbers)
 {
     auto contact = lookupBySourceUid(sourceUid);
+
+    QMutexLocker lock(&m_feederMutex);
+
     if (contact) {
         contact->setDisplayName(dn);
         contact->setName(name);
@@ -122,6 +130,9 @@ Contact *AddressBook::modifyContact(const QString &dn, const QString &sourceUid,
 void AddressBook::removeContact(const QString &sourceUid)
 {
     auto contact = lookupBySourceUid(sourceUid);
+
+    QMutexLocker lock(&m_feederMutex);
+
     if (contact) {
         m_contacts.remove(contact->id());
         m_contactsBySourceId.remove(contact->sourceUid());
@@ -210,6 +221,8 @@ Contact *AddressBook::lookupBySourceUid(const QString &sourceUid) const
 
 void AddressBook::clear()
 {
+    QMutexLocker lock(&m_feederMutex);
+
     qDeleteAll(m_contacts);
     m_contacts.clear();
     Q_EMIT contactsCleared();

--- a/src/contacts/AddressBook.h
+++ b/src/contacts/AddressBook.h
@@ -4,6 +4,7 @@
 
 #include <QObject>
 #include <QHash>
+#include <QMutex>
 
 class AddressBook : public QObject
 {
@@ -56,6 +57,8 @@ private:
     QHash<QString, Contact *> m_contacts;
     QHash<QString, Contact *> m_contactsBySourceId;
     QList<Contact::ContactSourceInfo> m_contactSourceInfos;
+
+    QMutex m_feederMutex;
 
 private Q_SLOTS:
     void updateSourceInfos(const Contact *contact);


### PR DESCRIPTION
Similar to `DateEvents`, the `AddressBook` may be updated in a concurrent manner - as such, it makes sense to use mutexes here as well.