### PR TITLE
fix: prevent changing of camera in confernece to cause inifinite loop

### DIFF
--- a/src/ui/JitsiConnector.cpp
+++ b/src/ui/JitsiConnector.cpp
@@ -116,6 +116,15 @@ void JitsiConnector::apiLoadingFinishedInternal()
     Q_EMIT isInitializedChanged();
 }
 
+void JitsiConnector::setVideoMutedInternal(bool value)
+{
+    if (m_isVideoMuted != value) {
+        m_isVideoMuted = value;
+        Q_EMIT isVideoMutedChanged();
+        updateVideoCallState();
+    }
+}
+
 void JitsiConnector::addError(QString type, QString name, QString message, bool isFatal,
                               QVariantMap details)
 {
@@ -380,7 +389,7 @@ api.addListener("videoAvailabilityChanged", data => {
 })
 
 api.addListener("videoMuteStatusChanged", data => {
-    jitsiConn.setVideoMuted(data.muted)
+    jitsiConn.setVideoMutedInternal(data.muted)
 })
 
 api.addListener("screenSharingStatusChanged", data => {

--- a/src/ui/JitsiConnector.h
+++ b/src/ui/JitsiConnector.h
@@ -39,6 +39,7 @@ public:
     // Should be called by the JS code once when all initialization is done
     Q_INVOKABLE void apiLoadingFinishedInternal();
 
+    Q_INVOKABLE void setVideoMutedInternal(bool value);
     Q_INVOKABLE void setVideoAvailableInternal(bool value);
     Q_INVOKABLE void setVideoQualityInternal(uint quality);
     Q_INVOKABLE void setIsSharingScreenInternal(bool value);


### PR DESCRIPTION
When changing the video camera in an ongoing Jitsi Meet conference, an infinite video mute toggle loop was started. This commit fixes it by introducing a new method to set the video mute state from the Jitsi Meet iframe api into the JitsiConnector.