### PR TITLE
fix(ui): jitsi meet chat now cleared when leaving room

### DIFF
--- a/src/chat/ChatMessage.h
+++ b/src/chat/ChatMessage.h
@@ -10,6 +10,7 @@ class ChatMessage
 
 public:
     enum class Flag {
+        Unknown = 0,
         PrivateMessage = 1 << 0,
         SystemMessage = 1 << 1,
         OwnMessage = 1 << 2,

--- a/src/chat/ConferenceChatRoom.cpp
+++ b/src/chat/ConferenceChatRoom.cpp
@@ -42,3 +42,10 @@ void ConferenceChatRoom::resetUnreadCount()
 {
     // Unsupported
 }
+
+void ConferenceChatRoom::clear()
+{
+    qDeleteAll(m_messages);
+    m_messages.clear();
+    Q_EMIT chatMessagesReset();
+}

--- a/src/chat/ConferenceChatRoom.h
+++ b/src/chat/ConferenceChatRoom.h
@@ -22,6 +22,7 @@ public:
     virtual void resetUnreadCount() override;
     virtual QList<ChatMessage *> chatMessages() const override { return m_messages; }
     virtual void sendMessage(const QString &message) override;
+    virtual void clear() override;
 
     /// Add a message object to be handled by this room. Takes ownership of that object.
     void addMessage(ChatMessage *chatMessageObj);

--- a/src/chat/IChatRoom.h
+++ b/src/chat/IChatRoom.h
@@ -28,6 +28,9 @@ public:
     /// Send a message in this room
     Q_INVOKABLE virtual void sendMessage(const QString &message) = 0;
 
+    /// Remove all messages. Must invoke chatMessagesReset() afterwards.
+    virtual void clear() = 0;
+
 Q_SIGNALS:
     void nameChanged(QString name);
     void notificationCountChanged(qsizetype count);

--- a/src/ui/JitsiConnector.cpp
+++ b/src/ui/JitsiConnector.cpp
@@ -140,7 +140,7 @@ void JitsiConnector::addIncomingMessage(QString fromId, QString nickName, QStrin
                              << "from" << fromId << nickName << "at" << stamp
                              << "as private message:" << isPrivateMessage << ":" << message;
 
-    ChatMessage::Flags flags = static_cast<ChatMessage::Flag>(0);
+    ChatMessage::Flags flags = ChatMessage::Flag::Unknown;
     if (isPrivateMessage) {
         flags |= ChatMessage::Flag::PrivateMessage;
     }
@@ -1163,6 +1163,8 @@ void JitsiConnector::leaveConference()
         m_inConferenceNotification = nullptr;
     }
 
+    m_chatRoom->clear();
+
     Q_EMIT executeLeaveRoomCommand();
     setConferenceName("");
     setDisplayName("");
@@ -1183,6 +1185,8 @@ void JitsiConnector::terminateConference()
         m_inConferenceNotification->deleteLater();
         m_inConferenceNotification = nullptr;
     }
+
+    m_chatRoom->clear();
 
     Q_EMIT executeEndConferenceCommand();
     setConferenceName("");


### PR DESCRIPTION
Before, when exiting a Jitsi Meet conference and entering another one, the chat messages of the former conference were still visible.