### PR TITLE
chore: add missing Jitsi notification icons

### DIFF
--- a/src/calendar/DateEventManager.cpp
+++ b/src/calendar/DateEventManager.cpp
@@ -275,7 +275,7 @@ void DateEventManager::onTimerTimeout()
                 auto notification = new Notification(tr("Conference starting soon"), summary,
                                                      Notification::Priority::high, &notMan);
 
-                notification->setIcon("dialog-information");
+                notification->setIcon(":/icons/gonnect.svg");
                 notification->addButton(tr("Join"), "join-meeting", "", {});
                 const auto notificationId = notMan.add(notification);
 

--- a/src/ui/JitsiConnector.cpp
+++ b/src/ui/JitsiConnector.cpp
@@ -161,7 +161,7 @@ void JitsiConnector::addIncomingMessage(QString fromId, QString nickName, QStrin
     if (settings.value("generic/jitsiChatAsNotifications", true).toBool()) {
         auto notification = new Notification(tr("New chat message"), message,
                                              Notification::Priority::normal, this);
-        notification->setIcon("dialog-information");
+        notification->setIcon(":/icons/gonnect.svg");
 
         m_chatNotifications.append(notification);
         NotificationManager::instance().add(notification);
@@ -1168,7 +1168,7 @@ void JitsiConnector::joinConference(const QString &conferenceId, const QString &
                                                | Notification::hideContentOnLockScreen);
     m_inConferenceNotification->setCategory("call.ongoing");
     m_inConferenceNotification->addButton(tr("Hang up"), "hangup", "call.hang-up", {});
-    m_inConferenceNotification->setIcon("dialog-information");
+    m_inConferenceNotification->setIcon(":/icons/gonnect.svg");
 
     QString ref = NotificationManager::instance().add(m_inConferenceNotification);
     connect(m_inConferenceNotification, &Notification::actionInvoked, this,


### PR DESCRIPTION
Previously there's been an issue in libnotify that caused icons to not be displayed, especially after the initial program start (https://gitlab.gnome.org/GNOME/libnotify/-/issues/55) - this has been fixed in newer versions of libnotify (> v0.8.4).

However, this also revealed that 3 Jitsi related notifications did not yet have an icon and as such, fell back to a blank page "dummy" icon, this has been fixed now.