### PR TITLE
fix(ui): loading of own avatar

### DIFF
--- a/src/contacts/Contact.h
+++ b/src/contacts/Contact.h
@@ -13,8 +13,8 @@ class Contact : public QObject
     QML_UNCREATABLE("")
 
     Q_PROPERTY(QString name READ name CONSTANT FINAL)
-    Q_PROPERTY(bool hasAvatar READ hasAvatar CONSTANT FINAL)
-    Q_PROPERTY(QString avatarPath READ avatarPath CONSTANT FINAL)
+    Q_PROPERTY(bool hasAvatar READ hasAvatar NOTIFY avatarChanged FINAL)
+    Q_PROPERTY(QString avatarPath READ avatarPath NOTIFY avatarChanged FINAL)
     Q_PROPERTY(bool hasBuddyState READ sipStatusSubscriptable CONSTANT FINAL)
     Q_PROPERTY(QString subscriptableNumber READ subscriptableNumber CONSTANT FINAL)
 

--- a/src/ui/ViewHelper.cpp
+++ b/src/ui/ViewHelper.cpp
@@ -41,6 +41,8 @@ ViewHelper::ViewHelper(QObject *parent) : QObject{ parent }
 
     connect(&AddressBook::instance(), &AddressBook::contactsReady, this,
             &ViewHelper::updateCurrentUser);
+    connect(&AddressBook::instance(), &AddressBook::contactAdded, this,
+            &ViewHelper::updateCurrentUser);
     connect(&AddressBook::instance(), &AddressBook::contactsCleared, this,
             &ViewHelper::updateCurrentUser);
     updateCurrentUser();


### PR DESCRIPTION
After contacts are loaded in different threads (see #276), the user's own avatar was not displayed correctly if loaded at a later time.