### PR TITLE
fix: avoid local time conversion for unknown origin timezones

### DIFF
--- a/src/calendar/caldav/CalDAVEventFeeder.cpp
+++ b/src/calendar/caldav/CalDAVEventFeeder.cpp
@@ -271,10 +271,10 @@ QDateTime CalDAVEventFeeder::createDateTimeFromTimeType(icaltimetype &datetime)
 
         See: https://www.rfc-editor.org/rfc/rfc5545#section-3.3.5
     */
-    int offset = icaltimezone_get_utc_offset(const_cast<icaltimezone *>(datetime.zone), &datetime,
-                                             &datetime.is_daylight);
+    icaltimezone *zone = const_cast<icaltimezone *>(datetime.zone);
+    int offset = icaltimezone_get_utc_offset(zone, &datetime, &datetime.is_daylight);
     QTimeZone convertZone(offset);
-    if (convertZone.isValid()) {
+    if (zone && convertZone.isValid()) {
         return QDateTime(QDate(datetime.year, datetime.month, datetime.day),
                          QTime(datetime.hour, datetime.minute, datetime.second), convertZone)
                 .toLocalTime();

--- a/src/calendar/eds/EDSEventFeeder.cpp
+++ b/src/calendar/eds/EDSEventFeeder.cpp
@@ -128,11 +128,11 @@ QDateTime EDSEventFeeder::createDateTimeFromTimeType(ICalTime *datetime)
         return QDateTime();
     }
 
+    ICalTimezone *zone = i_cal_time_get_timezone(datetime);
     int daylight = i_cal_time_is_daylight(datetime);
-    int offset =
-            i_cal_timezone_get_utc_offset(i_cal_time_get_timezone(datetime), datetime, &daylight);
+    int offset = i_cal_timezone_get_utc_offset(zone, datetime, &daylight);
     QTimeZone convertZone(offset);
-    if (convertZone.isValid()) {
+    if (zone && convertZone.isValid()) {
         return QDateTime(QDate(i_cal_time_get_year(datetime), i_cal_time_get_month(datetime),
                                i_cal_time_get_day(datetime)),
                          QTime(i_cal_time_get_hour(datetime), i_cal_time_get_minute(datetime),


### PR DESCRIPTION
Local time conversions will now only be done if the origin timezone can be determined.