### PR TITLE
fix: return an empty password if it's missing in QKeychain

### DIFF
--- a/src/AuthManager.cpp
+++ b/src/AuthManager.cpp
@@ -86,9 +86,10 @@ void AuthManager::init()
                      });
 
     Credentials::instance().get(
-            "jitsi/refreshToken", [this, sslConfig](bool error, const QString &data) {
-                if (error) {
-                    qCCritical(lcAuthManager) << "failed to set credentials:" << data;
+            "jitsi/refreshToken",
+            [this, sslConfig](CredentialsResponseState error, const QString &data) {
+                if (error == ResponseState_Error) {
+                    qCCritical(lcAuthManager) << "failed to get credentials:" << data;
                     return;
                 }
 
@@ -117,11 +118,12 @@ void AuthManager::storeRefreshToken(const QString &token) const
         return;
     }
 
-    Credentials::instance().set("jitsi/refreshToken", token, [](bool error, const QString &data) {
-        if (error) {
-            qCCritical(lcAuthManager) << "failed to set credentials:" << data;
-        }
-    });
+    Credentials::instance().set(
+            "jitsi/refreshToken", token, [](CredentialsResponseState state, const QString &data) {
+                if (state == ResponseState_Error) {
+                    qCCritical(lcAuthManager) << "failed to set credentials:" << data;
+                }
+            });
 }
 
 bool AuthManager::isOAuthAuthenticated() const

--- a/src/calendar/DateEventFeederManager.cpp
+++ b/src/calendar/DateEventFeederManager.cpp
@@ -54,13 +54,14 @@ void DateEventFeederManager::acquireSecret(const QString &configId,
 
     Credentials::instance().get(
             secretKey + "/secret",
-            [this, configId, secretKey, callback](bool error, const QString &secret) {
-                if (error) {
+            [this, configId, secretKey, callback](CredentialsResponseState state,
+                                                  const QString &secret) {
+                if (state == ResponseState_Error) {
                     qCWarning(lcDateEventFeederManager) << "failed to retrieve secret:" << secret;
                     return;
                 }
 
-                if (secret.isEmpty()) {
+                if (state == ResponseState_Empty) {
                     auto &viewHelper = ViewHelper::instance();
                     auto conn = connect(
                             &viewHelper, &ViewHelper::passwordResponded, this,
@@ -72,8 +73,9 @@ void DateEventFeederManager::acquireSecret(const QString &configId,
 
                                     Credentials::instance().set(
                                             secretKey + "/secret", password,
-                                            [](bool error, const QString &data) {
-                                                if (error) {
+                                            [](CredentialsResponseState state,
+                                               const QString &data) {
+                                                if (state == ResponseState_Error) {
                                                     qCCritical(lcDateEventFeederManager)
                                                             << "failed to set credentials:" << data;
                                                 }

--- a/src/chat/ChatConnectorManager.cpp
+++ b/src/chat/ChatConnectorManager.cpp
@@ -34,12 +34,13 @@ void ChatConnectorManager::saveRecoveryKey(const QString &settingsGroup, const Q
         return;
     }
 
-    credentials.set(
-            QString("%1/secret").arg(settingsGroup), key, [](bool error, const QString &misc) {
-                if (error) {
-                    qCCritical(lcChatConnectorManager) << "Error on saving recovery key:" << misc;
-                }
-            });
+    credentials.set(QString("%1/secret").arg(settingsGroup), key,
+                    [](CredentialsResponseState state, const QString &misc) {
+                        if (state == ResponseState_Error) {
+                            qCCritical(lcChatConnectorManager)
+                                    << "Error on saving recovery key:" << misc;
+                        }
+                    });
 }
 
 void ChatConnectorManager::saveAccessToken(const QString &settingsGroup, const QString &token) const
@@ -58,12 +59,13 @@ void ChatConnectorManager::saveAccessToken(const QString &settingsGroup, const Q
         return;
     }
 
-    credentials.set(
-            QString("%1/token").arg(settingsGroup), token, [](bool error, const QString &misc) {
-                if (error) {
-                    qCCritical(lcChatConnectorManager) << "Error on saving access token:" << misc;
-                }
-            });
+    credentials.set(QString("%1/token").arg(settingsGroup), token,
+                    [](CredentialsResponseState state, const QString &misc) {
+                        if (state == ResponseState_Error) {
+                            qCCritical(lcChatConnectorManager)
+                                    << "Error on saving access token:" << misc;
+                        }
+                    });
 }
 
 void ChatConnectorManager::init()

--- a/src/contacts/AddressBookManager.cpp
+++ b/src/contacts/AddressBookManager.cpp
@@ -152,13 +152,14 @@ void AddressBookManager::acquireSecret(const QString &group,
 
     Credentials::instance().get(
             secretKey + "/secret",
-            [this, group, secretKey, callback](bool error, const QString &secret) {
-                if (error) {
+            [this, group, secretKey, callback](CredentialsResponseState state,
+                                               const QString &secret) {
+                if (state == ResponseState_Error) {
                     qCWarning(lcAddressBookManager) << "failed to retrieve secret:" << secret;
                     return;
                 }
 
-                if (secret.isEmpty()) {
+                if (state == ResponseState_Empty) {
                     auto &viewHelper = ViewHelper::instance();
 
                     auto conn = connect(
@@ -171,8 +172,9 @@ void AddressBookManager::acquireSecret(const QString &group,
 
                                     Credentials::instance().set(
                                             secretKey + "/secret", password,
-                                            [secretKey](bool error, const QString &data) {
-                                                if (error) {
+                                            [secretKey](CredentialsResponseState state,
+                                                        const QString &data) {
+                                                if (state == ResponseState_Error) {
                                                     qCCritical(lcAddressBookManager)
                                                             << "failed to set credentials:" << data;
                                                 }

--- a/src/platform/Credentials.cpp
+++ b/src/platform/Credentials.cpp
@@ -30,11 +30,11 @@ void Credentials::initialize()
 #ifdef Q_OS_FLATPAK
     auto &sp = SecretPortal::instance();
     if (sp.isValid()) {
+        qCDebug(lcCredentials) << "Flatpak secret portal found.";
         if (sp.isInitialized()) {
             m_isSecretPortalInitialized = true;
             setIsInitialized(true);
             return;
-
         } else if (!sp.hasTriedInitialization()) {
             connect(
                     &sp, &SecretPortal::initializedChanged, this,
@@ -47,6 +47,8 @@ void Credentials::initialize()
                     Qt::ConnectionType::SingleShotConnection);
             return;
         }
+    } else {
+        qCDebug(lcCredentials) << "Flatpak secret portal not found.";
     }
 #endif
 
@@ -64,11 +66,11 @@ void Credentials::set(const QString &key, const QString &secret, CredentialsResp
             writeJob, &QKeychain::WritePasswordJob::finished, this,
             [this, writeJob, callback]() {
                 if (writeJob->error()) {
-                    callback(true,
+                    callback(ResponseState_Error,
                              tr("storing credentials failed: %1")
                                      .arg(qPrintable(writeJob->errorString())));
                 } else {
-                    callback(false, "");
+                    callback(ResponseState_Valid, "");
                 }
 
                 m_writeCredentialJobs.removeAll(writeJob);
@@ -97,23 +99,30 @@ void Credentials::get(const QString &key, CredentialsResponse callback)
                                        << "error:" << error << "secretEmpty:" << secret.isEmpty();
 
                 // Key is not present in keychain? Try to update it from Flatpak portal
-                if (m_isSecretPortalInitialized
-                    && (error == QKeychain::EntryNotFound || secret.isEmpty())) {
+                if (m_isSecretPortalInitialized && (error == QKeychain::EntryNotFound)) {
                     KeychainSettings keychainSettings;
 
                     qCDebug(lcCredentials) << "no secret from QKeychain; try secret portal";
 
 #ifdef Q_OS_FLATPAK
-                    qCDebug(lcCredentials) << "checking secret portal is valid";
+                    qCDebug(lcCredentials) << "checking if secret portal is valid";
 
                     auto &sp = SecretPortal::instance();
                     if (sp.isValid()) {
                         qCDebug(lcCredentials) << "secret portal is valid";
 
-                        const auto encryptedSecret = keychainSettings.value(key, "").toString();
-                        secret = sp.decrypt(encryptedSecret);
+                        // Create a default value with a low possibility of collision with an actual
+                        // secret.
+                        const QString VALUE_DEFAULT =
+                                "ebeet5iayaefoxee4ies8vueChaegaeH1zai0ANgohSe3iethu";
 
-                        if (!secret.isEmpty()) {
+                        const auto encryptedSecret =
+                                keychainSettings.value(key, VALUE_DEFAULT).toString();
+
+                        if (encryptedSecret != VALUE_DEFAULT) {
+                            // Got a secret from the portal, so migrate it to QKeychain.
+                            secret = sp.decrypt(encryptedSecret);
+
                             qCDebug(lcCredentials) << "migrate secret to QKeychain";
 
                             set(key, secret, [key](bool error, const QString &misc) {
@@ -123,21 +132,23 @@ void Credentials::get(const QString &key, CredentialsResponse callback)
                                             << "-" << misc;
                                 }
                             });
+
+                            callback(ResponseState_Valid, secret);
                         }
                     }
 #endif
 
-                    callback(false, secret);
+                    callback(ResponseState_Empty, secret);
                 } else if (error == QKeychain::EntryNotFound) {
                     qCDebug(lcCredentials) << "no secret found by QKeychain";
 
-                    callback(false, "");
+                    callback(ResponseState_Empty, "");
                 } else if (error != QKeychain::NoError) {
-                    callback(true,
+                    callback(ResponseState_Error,
                              tr("reading credentials failed: %1")
                                      .arg(qPrintable(readJob->errorString())));
                 } else {
-                    callback(false, secret);
+                    callback(ResponseState_Valid, secret);
                 }
 
                 m_readCredentialJobs.removeAll(readJob);

--- a/src/platform/Credentials.cpp
+++ b/src/platform/Credentials.cpp
@@ -93,18 +93,28 @@ void Credentials::get(const QString &key, CredentialsResponse callback)
                 auto error = readJob->error();
                 QString secret = readJob->textData();
 
+                qCDebug(lcCredentials) << "handling QKeychain respond - key:" << key
+                                       << "error:" << error << "secretEmpty:" << secret.isEmpty();
+
                 // Key is not present in keychain? Try to update it from Flatpak portal
                 if (m_isSecretPortalInitialized
                     && (error == QKeychain::EntryNotFound || secret.isEmpty())) {
                     KeychainSettings keychainSettings;
 
+                    qCDebug(lcCredentials) << "no secret from QKeychain; try secret portal";
+
 #ifdef Q_OS_FLATPAK
+                    qCDebug(lcCredentials) << "checking secret portal is valid";
+
                     auto &sp = SecretPortal::instance();
                     if (sp.isValid()) {
+                        qCDebug(lcCredentials) << "secret portal is valid";
+
                         const auto encryptedSecret = keychainSettings.value(key, "").toString();
                         secret = sp.decrypt(encryptedSecret);
 
                         if (!secret.isEmpty()) {
+                            qCDebug(lcCredentials) << "migrate secret to QKeychain";
 
                             set(key, secret, [key](bool error, const QString &misc) {
                                 if (error) {
@@ -119,7 +129,9 @@ void Credentials::get(const QString &key, CredentialsResponse callback)
 
                     callback(false, secret);
                 } else if (error == QKeychain::EntryNotFound) {
-                    callback(false, "inval!d");
+                    qCDebug(lcCredentials) << "no secret found by QKeychain";
+
+                    callback(false, "");
                 } else if (error != QKeychain::NoError) {
                     callback(true,
                              tr("reading credentials failed: %1")

--- a/src/platform/Credentials.h
+++ b/src/platform/Credentials.h
@@ -3,7 +3,10 @@
 #include <QObject>
 #include <qt6keychain/keychain.h>
 
-typedef std::function<void(bool error, const QString &misc)> CredentialsResponse;
+enum CredentialsResponseState { ResponseState_Valid, ResponseState_Empty, ResponseState_Error };
+
+typedef std::function<void(CredentialsResponseState state, const QString &misc)>
+        CredentialsResponse;
 
 class Credentials : public QObject
 {

--- a/src/sip/SIPAccount.cpp
+++ b/src/sip/SIPAccount.cpp
@@ -375,22 +375,31 @@ void SIPAccount::initialize()
         if (data.isEmpty()) {
             auto &cds = Credentials::instance();
             cds.get(auth + "/secret",
-                    [this, auth, scheme, realm, username, dataTypeValue](bool error,
-                                                                         const QString &data) {
-                        if (error) {
-                            qCCritical(lcSIPAccount) << "authentification failed:" << data;
+                    [this, auth, scheme, realm, username,
+                     dataTypeValue](CredentialsResponseState state, const QString &data) {
+                        if (state == ResponseState_Error) {
+                            qCCritical(lcSIPAccount)
+                                    << "error getting secret for authentification:" << data;
                             Q_EMIT initialized(false);
                             return;
                         }
 
-                        if (data.isEmpty()) {
-                            qCWarning(lcSIPAccount)
-                                    << "no password available for auth group" << auth;
+                        auto secret = data;
+
+                        if (state == ResponseState_Empty) {
+                            qCDebug(lcSIPAccount) << "no password available for auth group" << auth;
+                            // If no secret was configured, set an invalid secret to trigger an auth
+                            // error, if a password is needed.
+                            secret = QString("inval!d");
+                        }
+
+                        if (secret.isEmpty()) {
+                            qCDebug(lcSIPAccount) << "empty password set for auth group" << auth;
                         }
 
                         pj::AuthCredInfo cred(scheme.toStdString(), realm.toStdString(),
                                               username.toStdString(), dataTypeValue,
-                                              data.toStdString());
+                                              secret.toStdString());
 
                         m_accountConfig.sipConfig.authCreds.push_back(cred);
 
@@ -815,12 +824,13 @@ void SIPAccount::setCredentials(const QString &password)
     }
 
     // Update storage
-    Credentials::instance().set(
-            authGroup + "/secret", password, [authGroup](bool error, const QString &data) {
-                if (error) {
-                    qCCritical(lcSIPAccount) << "failed to set credentials:" << data;
-                }
-            });
+    Credentials::instance().set(authGroup + "/secret", password,
+                                [authGroup](CredentialsResponseState state, const QString &data) {
+                                    if (state == ResponseState_Error) {
+                                        qCCritical(lcSIPAccount)
+                                                << "failed to set credentials:" << data;
+                                    }
+                                });
 }
 
 bool SIPAccount::isSignalingEncrypted()

--- a/src/ui/JitsiConnector.cpp
+++ b/src/ui/JitsiConnector.cpp
@@ -587,8 +587,9 @@ void JitsiConnector::setRoomPassword(QString value)
     QString authGroup = "jitsiRoomPasswords/" + m_roomName;
 
     Credentials::instance().set(
-            authGroup, value, [this, value, authGroup](bool error, const QString &data) {
-                if (error) {
+            authGroup, value,
+            [this, value, authGroup](CredentialsResponseState state, const QString &data) {
+                if (state == ResponseState_Error) {
                     qCCritical(lcJitsiConnector) << "failed to set credentials:" << data;
                 } else {
                     Q_EMIT executePasswordCommand(value);
@@ -683,18 +684,19 @@ void JitsiConnector::onPasswordRequired()
 
         QString authGroup = "jitsiRoomPasswords/" + m_roomName;
 
-        Credentials::instance().get(authGroup, [this, authGroup](bool error, const QString &data) {
-            if (error) {
-                qCCritical(lcJitsiConnector) << "failed to get credentials:" << data;
-            } else {
-                if (!data.isEmpty()) {
-                    enterPassword(data, false);
-                    return;
-                }
-            }
+        Credentials::instance().get(
+                authGroup, [this, authGroup](CredentialsResponseState state, const QString &data) {
+                    if (state == ResponseState_Error) {
+                        qCCritical(lcJitsiConnector) << "failed to get credentials:" << data;
+                    } else {
+                        if (state != ResponseState_Empty) {
+                            enterPassword(data, false);
+                            return;
+                        }
+                    }
 
-            setIsPasswordRequired(true);
-        });
+                    setIsPasswordRequired(true);
+                });
     } else {
         setIsPasswordRequired(true);
     }
@@ -1289,8 +1291,9 @@ void JitsiConnector::enterPassword(const QString &password, bool rememberPasswor
         QString authGroup = "jitsiRoomPasswords/" + m_roomName;
 
         Credentials::instance().set(
-                authGroup, password, [this, password, authGroup](bool error, const QString &data) {
-                    if (error) {
+                authGroup, password,
+                [this, password, authGroup](CredentialsResponseState state, const QString &data) {
+                    if (state == ResponseState_Error) {
                         qCCritical(lcJitsiConnector) << "failed to set credentials:" << data;
                     } else {
                         Q_EMIT executePasswordCommand(password);


### PR DESCRIPTION
In the case the Flatpak Secrets Portal is not implemented (e.g. on KDE5) the credentials getter returned an constant password instead of an empty one.