### PR TITLE
fix: potential crash on HeadsetDevice destroyed

### DIFF
--- a/src/usb/HeadsetDeviceProxy.cpp
+++ b/src/usb/HeadsetDeviceProxy.cpp
@@ -156,6 +156,8 @@ bool HeadsetDeviceProxy::refreshDevice()
     if (devs.count()) {
         m_device = devs.first();
 
+        connect(m_device, &HeadsetDevice::destroyed, this, [this]() { m_device = nullptr; });
+
         connect(m_device, &HeadsetDevice::hookSwitch, this, [this]() {
             if (isEnabled()) {
                 Q_EMIT hookSwitch();


### PR DESCRIPTION
When HeadsetDevice gets destroyed, set m_device to nullptr again, do not dereference it anymore.

This fixes potential crashes later on.