### PR TITLE
chore: improved EDS integration and processing

### DIFF
--- a/src/calendar/DateEventManager.cpp
+++ b/src/calendar/DateEventManager.cpp
@@ -195,7 +195,6 @@ void DateEventManager::removeDateEvent(const QString &id, const QDateTime &start
         qsizetype index = 0;
         QMutableListIterator it(m_dateEvents);
         while (it.hasNext()) {
-            index++;
             const auto item = it.next();
             if (item && item->id() == dateEventId) {
                 const auto eventHash = item->getHash();
@@ -210,6 +209,7 @@ void DateEventManager::removeDateEvent(const QString &id, const QDateTime &start
 
                 Q_EMIT dateEventRemoved(index);
             }
+            index++;
         }
     }
 }
@@ -237,19 +237,17 @@ void DateEventManager::resetDateEvents()
 
 void DateEventManager::removeDateEventsBySource(const QString &source)
 {
-    qsizetype i = 0;
     QMutexLocker lock(&m_feederMutex);
     QMutableListIterator it(m_dateEvents);
     while (it.hasNext()) {
-        i++;
         const auto item = it.next();
         if (item && item->source() == source) {
             item->deleteLater();
             it.remove();
-
-            Q_EMIT dateEventRemoved(i);
         }
     }
+
+    Q_EMIT dateEventsCleared();
 }
 
 bool DateEventManager::isAddedDateEvent(const QString &id)

--- a/src/calendar/caldav/CalDAVEventFeeder.cpp
+++ b/src/calendar/caldav/CalDAVEventFeeder.cpp
@@ -67,7 +67,7 @@ void CalDAVEventFeeder::onParserFinished()
         QNetworkReply *reply = m_webdav.get(item.path());
         connect(
                 reply, &QNetworkReply::finished, this,
-                [reply, this]() {
+                [item, reply, this]() {
                     if (!reply) {
                         return;
                     }
@@ -78,10 +78,12 @@ void CalDAVEventFeeder::onParserFinished()
                     QMimeType type = db.mimeTypeForData(data);
                     if (type.name() == "text/calendar" && !data.isEmpty()
                         && responseDataChanged(data)) {
-                        DateEventManager &manager = DateEventManager::instance();
-                        manager.removeDateEventsBySource(m_config.source);
+                        QString concreteSource = QString("%1-%2").arg(m_config.source, item.name());
 
-                        processResponse(data);
+                        DateEventManager &manager = DateEventManager::instance();
+                        manager.removeDateEventsBySource(concreteSource);
+
+                        processResponse(data, concreteSource);
                     }
                 },
                 Qt::ConnectionType::SingleShotConnection);
@@ -100,7 +102,7 @@ void CalDAVEventFeeder::process(bool authFailed)
     });
 }
 
-void CalDAVEventFeeder::processResponse(const QByteArray &data)
+void CalDAVEventFeeder::processResponse(const QByteArray &data, const QString &source)
 {
     DateEventManager &manager = DateEventManager::instance();
 
@@ -206,8 +208,8 @@ void CalDAVEventFeeder::processResponse(const QByteArray &data)
                             && (recurStart >= m_config.timeRangeStart || recurMultiDay)) {
                             QString recurId =
                                     QString("%1-%2").arg(id).arg(recurStart.toMSecsSinceEpoch());
-                            manager.addDateEvent(recurId, m_config.source, recurStart, recurEnd,
-                                                 summary, location, description);
+                            manager.addDateEvent(recurId, source, recurStart, recurEnd, summary,
+                                                 location, description);
                         }
                     }
 
@@ -220,16 +222,13 @@ void CalDAVEventFeeder::processResponse(const QByteArray &data)
                     manager.removeDateEvent(id, start, end);
                 } else if (manager.isAddedDateEvent(id)) {
                     // Exists but modified
-                    manager.modifyDateEvent(id, m_config.source, start, end, summary, location,
-                                            description);
+                    manager.modifyDateEvent(id, source, start, end, summary, location, description);
                 } else {
                     // Does not exist, e.g. moved from past to future, different day
-                    manager.addDateEvent(id, m_config.source, start, end, summary, location,
-                                         description);
+                    manager.addDateEvent(id, source, start, end, summary, location, description);
                 }
             } else { // Normal event, no recurrence, or update of a recurrent instance
-                manager.addDateEvent(id, m_config.source, start, end, summary, location,
-                                     description);
+                manager.addDateEvent(id, source, start, end, summary, location, description);
             }
         }
     } else {

--- a/src/calendar/caldav/CalDAVEventFeeder.h
+++ b/src/calendar/caldav/CalDAVEventFeeder.h
@@ -33,7 +33,7 @@ private Q_SLOTS:
     void onParserFinished();
 
 private:
-    void processResponse(const QByteArray &data);
+    void processResponse(const QByteArray &data, const QString &source);
 
     bool responseDataChanged(const QByteArray &data);
     QDateTime createDateTimeFromTimeType(icaltimetype &datetime);

--- a/src/calendar/eds/EDSEventFeeder.cpp
+++ b/src/calendar/eds/EDSEventFeeder.cpp
@@ -22,24 +22,19 @@ EDSEventFeeder::EDSEventFeeder(QObject *parent, const QString &source, const QDa
 
 EDSEventFeeder::~EDSEventFeeder()
 {
-    if (m_registry) {
-        g_object_unref(m_registry);
-    }
+    g_clear_object(&m_registry);
     if (m_sources) {
         g_list_free_full(m_sources, g_object_unref);
     }
-    if (m_searchExpr) {
-        g_free(m_searchExpr);
-    }
+    g_clear_pointer(&m_searchExpr, g_free);
+    g_clear_object(&m_cancellable);
 
     for (auto client : std::as_const(m_clients)) {
-        g_object_unref(client);
-        client = nullptr;
+        g_clear_object(&client);
     }
 
     for (auto clientView : std::as_const(m_clientViews)) {
-        g_object_unref(clientView);
-        clientView = nullptr;
+        g_clear_object(&clientView);
     }
 
     if (m_sourcePromise) {
@@ -55,15 +50,16 @@ EDSEventFeeder::~EDSEventFeeder()
 
 void EDSEventFeeder::init()
 {
-    GError *error = nullptr;
+    m_cancellable = g_cancellable_new();
+
+    GError *error = NULL;
 
     // Create a source registry
-    m_registry = e_source_registry_new_sync(nullptr, &error);
+    m_registry = e_source_registry_new_sync(m_cancellable, &error);
     if (!m_registry) {
         if (error) {
             qCDebug(lcEDSEventFeeder) << "Can't create registry:" << error->message;
-            g_error_free(error);
-            error = nullptr;
+            g_clear_error(&error);
         }
         return;
     }
@@ -85,13 +81,13 @@ void EDSEventFeeder::init()
     m_sourceFuture = m_sourcePromise->future();
     m_futureWatcher = new QFutureWatcher<void>();
 
-    for (GList *iter = m_sources; iter != nullptr; iter = g_list_next(iter)) {
+    for (GList *iter = m_sources; iter != NULL; iter = g_list_next(iter)) {
         ESource *source = E_SOURCE(iter->data);
 
         qCDebug(lcEDSEventFeeder) << "Connecting to source" << e_source_get_display_name(source)
                                   << "(" << e_source_get_uid(source) << ")";
 
-        e_cal_client_connect(source, E_CAL_CLIENT_SOURCE_TYPE_EVENTS, -1, nullptr,
+        e_cal_client_connect(source, E_CAL_CLIENT_SOURCE_TYPE_EVENTS, -1, m_cancellable,
                              onEcalClientConnected, this);
     }
 
@@ -107,6 +103,8 @@ void EDSEventFeeder::init()
         if (!m_futureWatcher->isFinished()) {
             qCDebug(lcEDSEventFeeder) << "Failed to process EDS sources";
 
+            g_cancellable_cancel(m_cancellable);
+
             m_sourceFuture.cancel();
             m_futureWatcher->cancel();
         }
@@ -118,7 +116,8 @@ void EDSEventFeeder::init()
 void EDSEventFeeder::process()
 {
     for (auto client : std::as_const(m_clients)) {
-        e_cal_client_get_object_list(client, m_searchExpr, nullptr, onClientEventsRequested, this);
+        e_cal_client_get_object_list(client, m_searchExpr, m_cancellable, onClientEventsRequested,
+                                     this);
     }
 }
 
@@ -152,8 +151,8 @@ void EDSEventFeeder::onEcalClientConnected(GObject *source_object, GAsyncResult 
 {
     Q_UNUSED(source_object)
 
-    GError *error = nullptr;
-    ECalClient *client = nullptr;
+    GError *error = NULL;
+    ECalClient *client = NULL;
 
     EDSEventFeeder *feeder = static_cast<EDSEventFeeder *>(user_data);
     if (feeder) {
@@ -161,12 +160,12 @@ void EDSEventFeeder::onEcalClientConnected(GObject *source_object, GAsyncResult 
         if (error) {
             qCDebug(lcEDSEventFeeder)
                     << "Can't retrieve finished client connection:" << error->message;
-            g_error_free(error);
-            error = nullptr;
+            g_clear_error(&error);
             return;
         }
 
-        e_cal_client_get_view(client, feeder->m_searchExpr, nullptr, onViewCreated, feeder);
+        e_cal_client_get_view(client, feeder->m_searchExpr, feeder->m_cancellable, onViewCreated,
+                              feeder);
     }
 }
 
@@ -183,8 +182,7 @@ void EDSEventFeeder::onViewComplete(ECalClientView *view, GError *error, gpointe
         Otherwise, future view updates would cause duplicate signal connections.
     */
     guint signalId = g_signal_lookup("complete", G_OBJECT_TYPE(view));
-    g_signal_handlers_disconnect_matched(view, G_SIGNAL_MATCH_ID, signalId, 0, nullptr, nullptr,
-                                         nullptr);
+    g_signal_handlers_disconnect_matched(view, G_SIGNAL_MATCH_ID, signalId, 0, NULL, NULL, NULL);
 
     if (error) {
         qCCritical(lcEDSEventFeeder) << "Failed to wait for view completion, unable to subscribe "
@@ -244,19 +242,19 @@ void EDSEventFeeder::processEventsAdded(ECalClientView *view)
 
     if (client) {
         if (!m_clients.contains(client)) {
-            g_object_unref(client);
+            g_clear_object(&client);
             return;
         }
 
         // Use a class-managed reference instead
         const auto idx = m_clients.indexOf(client);
-        g_object_unref(client);
+        g_clear_object(&client);
 
         QString concreteSource = QString("%1-%2").arg(
                 m_source, e_source_get_uid(e_client_get_source(E_CLIENT(m_clients.at(idx)))));
         manager.removeDateEventsBySource(concreteSource);
 
-        e_cal_client_get_object_list(m_clients.at(idx), m_searchExpr, nullptr,
+        e_cal_client_get_object_list(m_clients.at(idx), m_searchExpr, m_cancellable,
                                      onClientEventsRequested, this);
     }
 }
@@ -268,18 +266,18 @@ void EDSEventFeeder::processEventsModified(ECalClientView *view)
 
     if (client) {
         if (!m_clients.contains(client)) {
-            g_object_unref(client);
+            g_clear_object(&client);
             return;
         }
 
         const auto idx = m_clients.indexOf(client);
-        g_object_unref(client);
+        g_clear_object(&client);
 
         QString concreteSource = QString("%1-%2").arg(
                 m_source, e_source_get_uid(e_client_get_source(E_CLIENT(m_clients.at(idx)))));
         manager.removeDateEventsBySource(concreteSource);
 
-        e_cal_client_get_object_list(m_clients.at(idx), m_searchExpr, nullptr,
+        e_cal_client_get_object_list(m_clients.at(idx), m_searchExpr, m_cancellable,
                                      onClientEventsRequested, this);
     }
 }
@@ -291,35 +289,34 @@ void EDSEventFeeder::processEventsRemoved(ECalClientView *view)
 
     if (client) {
         if (!m_clients.contains(client)) {
-            g_object_unref(client);
+            g_clear_object(&client);
             return;
         }
 
         const auto idx = m_clients.indexOf(client);
-        g_object_unref(client);
+        g_clear_object(&client);
 
         QString concreteSource = QString("%1-%2").arg(
                 m_source, e_source_get_uid(e_client_get_source(E_CLIENT(m_clients.at(idx)))));
         manager.removeDateEventsBySource(concreteSource);
 
-        e_cal_client_get_object_list(m_clients.at(idx), m_searchExpr, nullptr,
+        e_cal_client_get_object_list(m_clients.at(idx), m_searchExpr, m_cancellable,
                                      onClientEventsRequested, this);
     }
 }
 
 void EDSEventFeeder::onViewCreated(GObject *source_object, GAsyncResult *result, gpointer user_data)
 {
-    GError *error = nullptr;
+    GError *error = NULL;
     ECalClient *client = E_CAL_CLIENT(source_object);
-    ECalClientView *view = nullptr;
+    ECalClientView *view = NULL;
     EDSEventFeeder *feeder = static_cast<EDSEventFeeder *>(user_data);
 
     if (feeder && client) {
         if (!e_cal_client_get_view_finish(client, result, &view, &error)) {
             if (error) {
                 qCCritical(lcEDSEventFeeder) << "Can't retrieve finished view:" << error->message;
-                g_error_free(error);
-                error = nullptr;
+                g_clear_error(&error);
             }
             return;
         }
@@ -328,8 +325,7 @@ void EDSEventFeeder::onViewCreated(GObject *source_object, GAsyncResult *result,
         e_cal_client_view_start(view, &error);
         if (error) {
             qCCritical(lcEDSEventFeeder) << "Can't start view:" << error->message;
-            g_error_free(error);
-            error = nullptr;
+            g_clear_error(&error);
             return;
         }
         feeder->m_clientViews.append(view);
@@ -344,8 +340,8 @@ void EDSEventFeeder::onViewCreated(GObject *source_object, GAsyncResult *result,
 void EDSEventFeeder::onClientEventsRequested(GObject *source_object, GAsyncResult *result,
                                              gpointer user_data)
 {
-    GError *error = nullptr;
-    GSList *components = nullptr;
+    GError *error = NULL;
+    GSList *components = NULL;
 
     EDSEventFeeder *feeder = static_cast<EDSEventFeeder *>(user_data);
     if (feeder) {
@@ -353,8 +349,7 @@ void EDSEventFeeder::onClientEventsRequested(GObject *source_object, GAsyncResul
                                                  &error)) {
             if (error) {
                 qCCritical(lcEDSEventFeeder) << "Can't retrieve events:" << error->message;
-                g_error_free(error);
-                error = nullptr;
+                g_clear_error(&error);
             }
             return;
         }
@@ -376,7 +371,7 @@ void EDSEventFeeder::processEvents(QString clientName, QString clientUid, GSList
 
     QMap<QString, QList<QDateTime>> exdatesById;
 
-    for (GSList *item = components; item != nullptr; item = g_slist_next(item)) {
+    for (GSList *item = components; item != NULL; item = g_slist_next(item)) {
         ICalComponent *component = I_CAL_COMPONENT(item->data);
         if (component && i_cal_component_isa(component) == I_CAL_VEVENT_COMPONENT) {
             QString id = i_cal_component_get_uid(component);
@@ -391,7 +386,7 @@ void EDSEventFeeder::processEvents(QString clientName, QString clientUid, GSList
             bool isRecurrent = false;
             ICalProperty *prop =
                     i_cal_component_get_first_property(component, I_CAL_RRULE_PROPERTY);
-            ICalRecurrence *rrule = nullptr;
+            ICalRecurrence *rrule = NULL;
             if (prop) {
                 isRecurrent = true;
                 rrule = i_cal_property_get_rrule(prop);
@@ -437,11 +432,11 @@ void EDSEventFeeder::processEvents(QString clientName, QString clientUid, GSList
 
             if (isRecurrent) { // Recurrent origin event, parsed first
                 // Get EXDATE's
-                ICalTime *exdate = nullptr;
+                ICalTime *exdate = NULL;
                 QList<QDateTime> exdates;
                 for (ICalProperty *prop =
                              i_cal_component_get_first_property(component, I_CAL_EXDATE_PROPERTY);
-                     prop != nullptr;
+                     prop != NULL;
                      prop = i_cal_component_get_next_property(component, I_CAL_EXDATE_PROPERTY)) {
                     exdate = i_cal_property_get_exdate(prop);
                     exdates.append(createDateTimeFromTimeType(exdate));
@@ -505,7 +500,7 @@ void EDSEventFeeder::processEvents(QString clientName, QString clientUid, GSList
     }
 
     g_slist_free_full(components, g_object_unref);
-    components = nullptr;
+    components = NULL;
 
     qCInfo(lcEDSEventFeeder) << "Loaded events of source" << clientName << "(" << clientUid << ")";
 }

--- a/src/calendar/eds/EDSEventFeeder.h
+++ b/src/calendar/eds/EDSEventFeeder.h
@@ -60,11 +60,13 @@ private:
     QDateTime m_timeRangeStart;
     QDateTime m_timeRangeEnd;
 
-    ESourceRegistry *m_registry = nullptr;
-    GList *m_sources = nullptr;
-    gchar *m_searchExpr = nullptr;
+    ESourceRegistry *m_registry = NULL;
+    GList *m_sources = NULL;
+    gchar *m_searchExpr = NULL;
     QList<ECalClient *> m_clients;
     QList<ECalClientView *> m_clientViews;
+
+    GCancellable *m_cancellable = NULL;
 
     int m_sourceCount = 0;
     std::atomic<int> m_clientCount = 0;

--- a/src/contacts/eds/EDSAddressBookFeeder.cpp
+++ b/src/contacts/eds/EDSAddressBookFeeder.cpp
@@ -20,24 +20,19 @@ EDSAddressBookFeeder::EDSAddressBookFeeder(const QString &group, AddressBookMana
 
 EDSAddressBookFeeder::~EDSAddressBookFeeder()
 {
-    if (m_registry) {
-        g_object_unref(m_registry);
-    }
+    g_clear_object(&m_registry);
     if (m_sources) {
         g_list_free_full(m_sources, g_object_unref);
     }
-    if (m_searchExpr) {
-        g_free(m_searchExpr);
-    }
+    g_clear_pointer(&m_searchExpr, g_free);
+    g_clear_object(&m_cancellable);
 
     for (auto client : std::as_const(m_clients)) {
-        g_object_unref(client);
-        client = nullptr;
+        g_clear_object(&client);
     }
 
     for (auto clientView : std::as_const(m_clientViews)) {
-        g_object_unref(clientView);
-        clientView = nullptr;
+        g_clear_object(&clientView);
     }
 
     if (m_sourcePromise) {
@@ -53,15 +48,16 @@ EDSAddressBookFeeder::~EDSAddressBookFeeder()
 
 void EDSAddressBookFeeder::init()
 {
-    GError *error = nullptr;
+    m_cancellable = g_cancellable_new();
+
+    GError *error = NULL;
 
     // Create a source registry
-    m_registry = e_source_registry_new_sync(nullptr, &error);
+    m_registry = e_source_registry_new_sync(m_cancellable, &error);
     if (!m_registry) {
         if (error) {
             qCDebug(lcEDSAddressBookFeeder) << "Can't create registry:" << error->message;
-            g_error_free(error);
-            error = nullptr;
+            g_clear_error(&error);
         }
         return;
     }
@@ -77,14 +73,14 @@ void EDSAddressBookFeeder::init()
     // Prepare the search query
     EBookQuery *query = e_book_query_any_field_contains("");
     m_searchExpr = e_book_query_to_string(query);
-    e_book_query_unref(query);
+    g_clear_pointer (&query, e_book_query_unref);
 
     // Clients and signals
     m_sourcePromise = new QPromise<void>();
     m_sourceFuture = m_sourcePromise->future();
     m_futureWatcher = new QFutureWatcher<void>();
 
-    for (GList *iter = m_sources; iter != nullptr; iter = g_list_next(iter)) {
+    for (GList *iter = m_sources; iter != NULL; iter = g_list_next(iter)) {
         ESource *source = E_SOURCE(iter->data);
 
         QString sourceInfo =
@@ -92,7 +88,7 @@ void EDSAddressBookFeeder::init()
 
         qCDebug(lcEDSAddressBookFeeder) << "Connecting to source" << sourceInfo;
 
-        e_book_client_connect(source, -1, nullptr, onEbookClientConnected, this);
+        e_book_client_connect(source, -1, m_cancellable, onEbookClientConnected, this);
     }
 
     m_sourcePromise->start();
@@ -106,6 +102,8 @@ void EDSAddressBookFeeder::init()
     QTimer::singleShot(5s, this, [this]() {
         if (!m_futureWatcher->isFinished()) {
             qCDebug(lcEDSAddressBookFeeder) << "Failed to process EDS sources";
+
+            g_cancellable_cancel(m_cancellable);
 
             m_sourceFuture.cancel();
             m_futureWatcher->cancel();
@@ -166,7 +164,7 @@ QStringList EDSAddressBookFeeder::getList(EContact *contact, EContactField id)
 
     if (contact) {
         GList *items = static_cast<GList *>(e_contact_get(contact, id));
-        for (GList *item = items; item != nullptr; item = g_list_next(item)) {
+        for (GList *item = items; item != NULL; item = g_list_next(item)) {
             const gchar *result = static_cast<const gchar *>(item->data);
             if (result) {
                 results.append(QString::fromUtf8(result));
@@ -194,8 +192,7 @@ void EDSAddressBookFeeder::onViewComplete(EBookClientView *view, GError *error, 
         Otherwise, future view updates would cause duplicate signal connections.
     */
     guint signalId = g_signal_lookup("complete", G_OBJECT_TYPE(view));
-    g_signal_handlers_disconnect_matched(view, G_SIGNAL_MATCH_ID, signalId, 0, nullptr, nullptr,
-                                         nullptr);
+    g_signal_handlers_disconnect_matched(view, G_SIGNAL_MATCH_ID, signalId, 0, NULL, NULL, NULL);
 
     if (error) {
         qCCritical(lcEDSAddressBookFeeder)
@@ -257,7 +254,7 @@ void EDSAddressBookFeeder::processContactsAdded(GSList *contacts)
 {
     auto &addressbook = AddressBook::instance();
 
-    for (GSList *item = contacts; item != nullptr; item = g_slist_next(item)) {
+    for (GSList *item = contacts; item != NULL; item = g_slist_next(item)) {
         if (EContact *eContact = E_CONTACT(item->data)) {
             QDateTime changed =
                     QDateTime::fromString(getField(eContact, E_CONTACT_REV), Qt::ISODate);
@@ -292,7 +289,7 @@ void EDSAddressBookFeeder::processContactsModified(GSList *contacts)
 {
     auto &addressbook = AddressBook::instance();
 
-    for (GSList *item = contacts; item != nullptr; item = g_slist_next(item)) {
+    for (GSList *item = contacts; item != NULL; item = g_slist_next(item)) {
         if (EContact *eContact = E_CONTACT(item->data)) {
             QDateTime changed =
                     QDateTime::fromString(getField(eContact, E_CONTACT_REV), Qt::ISODate);
@@ -329,7 +326,7 @@ void EDSAddressBookFeeder::processContactsRemoved(GSList *uids)
 {
     auto &addressbook = AddressBook::instance();
 
-    for (GSList *item = uids; item != nullptr; item = g_slist_next(item)) {
+    for (GSList *item = uids; item != NULL; item = g_slist_next(item)) {
         const gchar *uid = static_cast<const gchar *>(item->data);
         if (uid) {
             // Do not keep images of deleted contacts
@@ -346,8 +343,8 @@ void EDSAddressBookFeeder::onEbookClientConnected(GObject *source_object, GAsync
 {
     Q_UNUSED(source_object)
 
-    GError *error = nullptr;
-    EBookClient *client = nullptr;
+    GError *error = NULL;
+    EBookClient *client = NULL;
 
     EDSAddressBookFeeder *feeder = static_cast<EDSAddressBookFeeder *>(user_data);
     if (feeder) {
@@ -355,21 +352,21 @@ void EDSAddressBookFeeder::onEbookClientConnected(GObject *source_object, GAsync
         if (error) {
             qCDebug(lcEDSAddressBookFeeder)
                     << "Can't retrieve finished client connection:" << error->message;
-            g_error_free(error);
-            error = nullptr;
+            g_clear_error(&error);
             return;
         }
 
-        e_book_client_get_view(client, feeder->m_searchExpr, nullptr, onViewCreated, feeder);
+        e_book_client_get_view(client, feeder->m_searchExpr, feeder->m_cancellable, onViewCreated,
+                               feeder);
     }
 }
 
 void EDSAddressBookFeeder::onViewCreated(GObject *source_object, GAsyncResult *result,
                                          gpointer user_data)
 {
-    GError *error = nullptr;
+    GError *error = NULL;
     EBookClient *client = E_BOOK_CLIENT(source_object);
-    EBookClientView *view = nullptr;
+    EBookClientView *view = NULL;
     EDSAddressBookFeeder *feeder = static_cast<EDSAddressBookFeeder *>(user_data);
 
     if (feeder && client) {
@@ -377,8 +374,7 @@ void EDSAddressBookFeeder::onViewCreated(GObject *source_object, GAsyncResult *r
             if (error) {
                 qCCritical(lcEDSAddressBookFeeder)
                         << "Can't retrieve finished view:" << error->message;
-                g_error_free(error);
-                error = nullptr;
+                g_clear_error(&error);
             }
             return;
         }
@@ -387,8 +383,7 @@ void EDSAddressBookFeeder::onViewCreated(GObject *source_object, GAsyncResult *r
         e_book_client_view_start(view, &error);
         if (error) {
             qCCritical(lcEDSAddressBookFeeder) << "Can't start view:" << error->message;
-            g_error_free(error);
-            error = nullptr;
+            g_clear_error(&error);
             return;
         }
         feeder->m_clientViews.append(view);
@@ -404,8 +399,8 @@ void EDSAddressBookFeeder::onViewCreated(GObject *source_object, GAsyncResult *r
 void EDSAddressBookFeeder::onClientContactsRequested(GObject *source_object, GAsyncResult *result,
                                                      gpointer user_data)
 {
-    GError *error = nullptr;
-    GSList *contacts = nullptr;
+    GError *error = NULL;
+    GSList *contacts = NULL;
 
     EDSAddressBookFeeder *feeder = static_cast<EDSAddressBookFeeder *>(user_data);
     if (feeder) {
@@ -413,8 +408,7 @@ void EDSAddressBookFeeder::onClientContactsRequested(GObject *source_object, GAs
                                                &error)) {
             if (error) {
                 qCCritical(lcEDSAddressBookFeeder) << "Can't retrieve contacts:" << error->message;
-                g_error_free(error);
-                error = nullptr;
+                g_clear_error(&error);
             }
             return;
         }
@@ -434,7 +428,7 @@ void EDSAddressBookFeeder::processContacts(QString clientInfo, GSList *contacts)
     unsigned contactCount = 0;
     auto &addressbook = AddressBook::instance();
 
-    for (GSList *item = contacts; item != nullptr; item = g_slist_next(item)) {
+    for (GSList *item = contacts; item != NULL; item = g_slist_next(item)) {
         if (EContact *eContact = E_CONTACT(item->data)) {
             QDateTime changed =
                     QDateTime::fromString(getField(eContact, E_CONTACT_REV), Qt::ISODate);
@@ -467,7 +461,7 @@ void EDSAddressBookFeeder::processContacts(QString clientInfo, GSList *contacts)
     }
 
     g_slist_free_full(contacts, g_object_unref);
-    contacts = nullptr;
+    contacts = NULL;
 
     qCInfo(lcEDSAddressBookFeeder)
             << "Loaded" << contactCount << "contact(s) of source" << clientInfo;
@@ -523,6 +517,7 @@ void EDSAddressBookFeeder::addAvatar(QString id, EContact *contact, QDateTime ch
 void EDSAddressBookFeeder::feedAddressBook()
 {
     for (auto client : std::as_const(m_clients)) {
-        e_book_client_get_contacts(client, m_searchExpr, nullptr, onClientContactsRequested, this);
+        e_book_client_get_contacts(client, m_searchExpr, m_cancellable, onClientContactsRequested,
+                                   this);
     }
 }

--- a/src/contacts/eds/EDSAddressBookFeeder.cpp
+++ b/src/contacts/eds/EDSAddressBookFeeder.cpp
@@ -73,7 +73,7 @@ void EDSAddressBookFeeder::init()
     // Prepare the search query
     EBookQuery *query = e_book_query_any_field_contains("");
     m_searchExpr = e_book_query_to_string(query);
-    g_clear_pointer (&query, e_book_query_unref);
+    g_clear_pointer(&query, e_book_query_unref);
 
     // Clients and signals
     m_sourcePromise = new QPromise<void>();

--- a/src/contacts/eds/EDSAddressBookFeeder.h
+++ b/src/contacts/eds/EDSAddressBookFeeder.h
@@ -60,11 +60,13 @@ private:
     QString m_group;
     BlockInfo m_blockInfo;
 
-    ESourceRegistry *m_registry = nullptr;
-    GList *m_sources = nullptr;
-    gchar *m_searchExpr = nullptr;
+    ESourceRegistry *m_registry = NULL;
+    GList *m_sources = NULL;
+    gchar *m_searchExpr = NULL;
     QList<EBookClient *> m_clients;
     QList<EBookClientView *> m_clientViews;
+
+    GCancellable *m_cancellable = NULL;
 
     int m_sourceCount = 0;
     std::atomic<int> m_clientCount = 0;

--- a/src/ui/DateEventsModel.cpp
+++ b/src/ui/DateEventsModel.cpp
@@ -11,10 +11,11 @@ DateEventsModel::DateEventsModel(QObject *parent) : QAbstractListModel{ parent }
         endResetModel();
     });
 
-    connect(&manager, &DateEventManager::dateEventAdded, this, [this](qsizetype index, DateEvent *) {
-        beginInsertRows(QModelIndex(), index, index);
-        endInsertRows();
-    });
+    connect(&manager, &DateEventManager::dateEventAdded, this,
+            [this](qsizetype index, DateEvent *) {
+                beginInsertRows(QModelIndex(), index, index);
+                endInsertRows();
+            });
 
     connect(&manager, &DateEventManager::dateEventsModified, this, [this]() {
         beginResetModel();

--- a/src/ui/DateEventsModel.cpp
+++ b/src/ui/DateEventsModel.cpp
@@ -11,9 +11,9 @@ DateEventsModel::DateEventsModel(QObject *parent) : QAbstractListModel{ parent }
         endResetModel();
     });
 
-    connect(&manager, &DateEventManager::dateEventAdded, this, [this](qsizetype, DateEvent *) {
-        beginResetModel();
-        endResetModel();
+    connect(&manager, &DateEventManager::dateEventAdded, this, [this](qsizetype index, DateEvent *) {
+        beginInsertRows(QModelIndex(), index, index);
+        endInsertRows();
     });
 
     connect(&manager, &DateEventManager::dateEventsModified, this, [this]() {
@@ -21,9 +21,9 @@ DateEventsModel::DateEventsModel(QObject *parent) : QAbstractListModel{ parent }
         endResetModel();
     });
 
-    connect(&manager, &DateEventManager::dateEventRemoved, this, [this](qsizetype) {
-        beginResetModel();
-        endResetModel();
+    connect(&manager, &DateEventManager::dateEventRemoved, this, [this](qsizetype index) {
+        beginRemoveRows(QModelIndex(), index, index);
+        endRemoveRows();
     });
 }
 


### PR DESCRIPTION
Introduces simpler date event model updates instead of complete model resets where applicable.

Fixes a CalDAV concrete source bug, that'd cause all events to be cleared, even if only one concrete calendar has been updated.

The EDS plugins will also cancel all currently active async methods if the 5s timout has been reached - thus guaranteeing that the plugin stops cleanly.

Additionally, any `g_unref` methods have been replaced by their more convenient `g_clear` counterparts, as they check for null prior to freeing, while also setting the pointer variable to NULL in the end.