### PR TITLE
fix: restore functionality for feeders without network requirements

### DIFF
--- a/src/calendar/DateEventFeederManager.cpp
+++ b/src/calendar/DateEventFeederManager.cpp
@@ -144,7 +144,8 @@ void DateEventFeederManager::processQueue()
                 }
 
                 if (!networkHelper.hasConnectivity()) {
-                    qCWarning(lcDateEventFeederManager) << "No network connectivity";
+                    qCWarning(lcDateEventFeederManager)
+                            << "No connectivity state yet - trying later";
                     networkAvailable = false;
                     setupReconnectSignal();
                     continue;

--- a/src/calendar/DateEventFeederManager.cpp
+++ b/src/calendar/DateEventFeederManager.cpp
@@ -139,7 +139,7 @@ void DateEventFeederManager::processQueue()
                 }
 
                 if (!urlToCheck.isValid()) {
-                    qCCritical(lcDateEventFeederManager) << "Url is invalid:" << urlToCheck;
+                    qCCritical(lcDateEventFeederManager) << "URL is invalid:" << urlToCheck;
                     continue;
                 }
 

--- a/src/calendar/DateEventFeederManager.cpp
+++ b/src/calendar/DateEventFeederManager.cpp
@@ -131,7 +131,9 @@ void DateEventFeederManager::processQueue()
         if (auto feeder = m_dateEventFeeders.value(configId, nullptr)) {
             QUrl urlToCheck = feeder->networkCheckURL();
 
-            if (!urlToCheck.isEmpty()) {
+            if (urlToCheck.isEmpty()) {
+                feeder->init();
+            } else {
                 if (!networkAvailable) {
                     continue;
                 }
@@ -152,8 +154,8 @@ void DateEventFeederManager::processQueue()
                         .then(this, [feeder, urlToCheck, this](bool isReachable) {
                             if (isReachable) {
                                 QMutexLocker mutex(&m_queueMutex);
-                                feeder->init();
 
+                                feeder->init();
                             } else {
                                 qCWarning(lcDateEventFeederManager)
                                         << "Feeder url" << urlToCheck << "is not reachable";

--- a/src/calendar/DateEventFeederManager.cpp
+++ b/src/calendar/DateEventFeederManager.cpp
@@ -159,7 +159,7 @@ void DateEventFeederManager::processQueue()
                                 feeder->init();
                             } else {
                                 qCWarning(lcDateEventFeederManager)
-                                        << "Feeder url" << urlToCheck << "is not reachable";
+                                        << "Feeder URL" << urlToCheck << "is not reachable";
                                 setupReconnectSignal();
                             }
                         });

--- a/src/contacts/AddressBookManager.cpp
+++ b/src/contacts/AddressBookManager.cpp
@@ -112,7 +112,7 @@ void AddressBookManager::processAddressBookQueue()
                 }
 
                 if (!checkURL.isValid()) {
-                    qCCritical(lcAddressBookManager) << "Url is invalid:" << checkURL;
+                    qCCritical(lcAddressBookManager) << "URL is invalid:" << checkURL;
                     continue;
                 }
 

--- a/src/contacts/AddressBookManager.cpp
+++ b/src/contacts/AddressBookManager.cpp
@@ -103,7 +103,10 @@ void AddressBookManager::processAddressBookQueue()
             // the network helper / portal. If we've no connectivity, trigger on
             // connectivityChanged signal to recheck again.
             QUrl checkURL = feeder->networkCheckURL();
-            if (!checkURL.isEmpty()) {
+
+            if (checkURL.isEmpty()) {
+                feeder->process();
+            } else {
                 if (!networkAvailable) {
                     continue;
                 }

--- a/src/contacts/AddressBookManager.cpp
+++ b/src/contacts/AddressBookManager.cpp
@@ -136,7 +136,7 @@ void AddressBookManager::processAddressBookQueue()
                         Q_EMIT AddressBook::instance().contactsReady();
                     } else {
                         qCWarning(lcAddressBookManager)
-                                << "Feeder url" << checkURL << "is not reachable";
+                                << "Feeder URL" << checkURL << "is not reachable";
                         connect(
                                 &NetworkHelper::instance(), &NetworkHelper::connectivityChanged,
                                 this, [this]() { processAddressBookQueue(); },

--- a/src/contacts/AddressBookManager.cpp
+++ b/src/contacts/AddressBookManager.cpp
@@ -111,8 +111,13 @@ void AddressBookManager::processAddressBookQueue()
                     continue;
                 }
 
+                if (!checkURL.isValid()) {
+                    qCCritical(lcAddressBookManager) << "Url is invalid:" << checkURL;
+                    continue;
+                }
+
                 if (!nh.hasConnectivity()) {
-                    qCWarning(lcAddressBookManager) << "no connectivity state yet - trying later";
+                    qCWarning(lcAddressBookManager) << "No connectivity state yet - trying later";
 
                     networkAvailable = false;
                     connect(
@@ -130,7 +135,8 @@ void AddressBookManager::processAddressBookQueue()
                         feeder->process();
                         Q_EMIT AddressBook::instance().contactsReady();
                     } else {
-                        qCWarning(lcAddressBookManager) << checkURL << "is not reachable";
+                        qCWarning(lcAddressBookManager)
+                                << "Feeder url" << checkURL << "is not reachable";
                         connect(
                                 &NetworkHelper::instance(), &NetworkHelper::connectivityChanged,
                                 this, [this]() { processAddressBookQueue(); },


### PR DESCRIPTION
Changes in #375 (0f54fe551d7154b16eed0597e6286a934b801edb) did not allow feeders that do not require a network connection (e.g. EDS) to run