### PR TITLE
fix: disable WMME in pjsip

### DIFF
--- a/resources/conan/recipes/pjproject/all/conanfile.py
+++ b/resources/conan/recipes/pjproject/all/conanfile.py
@@ -165,6 +165,7 @@ class PjSIPConan(ConanFile):
 
             if self.settings.os == "Windows":
                 file.write('\n\n#define PJ_HAS_SSL_SOCK 1\n')
+                file.write('\n\n#define PJMEDIA_AUDIO_DEV_HAS_WMME 0\n')
 
     def buildWindows(self):
         if self.options.shared:


### PR DESCRIPTION
gonnect uses its own AudioPort and disables pjsip port/device on linux (by using "extern"). Likewise disable it on windows, to make sure the AudioPort is used (only).