### PR TITLE
fix: raise window after showing it

### DIFF
--- a/src/StateManager.cpp
+++ b/src/StateManager.cpp
@@ -84,6 +84,7 @@ void StateManager::initialize()
         auto &cm = SIPCallManager::instance();
         if (action == "dial") {
             qobject_cast<Application *>(Application::instance())->rootWindow()->show();
+            qobject_cast<Application *>(Application::instance())->rootWindow()->raise();
         } else if (action == "hangup") {
             cm.endAllCalls();
         } else if (action == "redial") {


### PR DESCRIPTION
Required on windows: After calling show(), also call raise(), otherwise the window shows up behind whatever window(s) is currently visible. This is required for the global shortcut on windows.

Please check if this is needed (or useful) on linux as well, otherwise we can hide it behind an ifdef for windows only.
Can be tested with the global shortcut for "dial", CTRL+ALT+K by default.