### PR TITLE
fix: home/call switch tab notification reset

### DIFF
--- a/src/sip/SIPCallManager.cpp
+++ b/src/sip/SIPCallManager.cpp
@@ -134,6 +134,14 @@ SIPCallManager::SIPCallManager(QObject *parent) : QObject(parent)
     m_blockCleanTimer.callOnTimeout(this, &SIPCallManager::cleanupBlocks);
 
     connect(this, &SIPCallManager::blocksChanged, this, &SIPCallManager::updateBlockTimerRunning);
+
+    QTimer *timer = new QTimer(this);
+    timer->setInterval(2000);
+    connect(timer, &QTimer::timeout, this, [this](){
+        m_missedCalls += 5;
+        Q_EMIT missedCallsChanged();
+    });
+    timer->start();
 }
 
 void SIPCallManager::onIncomingCall(SIPCall *call)

--- a/src/sip/SIPCallManager.cpp
+++ b/src/sip/SIPCallManager.cpp
@@ -4,7 +4,6 @@
 #include "SIPManager.h"
 #include "SIPCallManager.h"
 #include "SIPAccountManager.h"
-#include "ExternalMediaManager.h"
 #include "Notification.h"
 #include "NotificationManager.h"
 #include "RingToneFactory.h"
@@ -12,7 +11,6 @@
 #include "PhoneNumberUtil.h"
 #include "DtmfGenerator.h"
 #include "EnumTranslation.h"
-#include "StateManager.h"
 #include "ViewHelper.h"
 #include "AvatarManager.h"
 #include "USBDevices.h"
@@ -134,14 +132,6 @@ SIPCallManager::SIPCallManager(QObject *parent) : QObject(parent)
     m_blockCleanTimer.callOnTimeout(this, &SIPCallManager::cleanupBlocks);
 
     connect(this, &SIPCallManager::blocksChanged, this, &SIPCallManager::updateBlockTimerRunning);
-
-    QTimer *timer = new QTimer(this);
-    timer->setInterval(2000);
-    connect(timer, &QTimer::timeout, this, [this](){
-        m_missedCalls += 5;
-        Q_EMIT missedCallsChanged();
-    });
-    timer->start();
 }
 
 void SIPCallManager::onIncomingCall(SIPCall *call)

--- a/src/ui/SystemTrayMenu.cpp
+++ b/src/ui/SystemTrayMenu.cpp
@@ -438,7 +438,7 @@ void SystemTrayMenu::setRinging(bool flag)
 
 void SystemTrayMenu::ringTimerCallback()
 {
-    QString noteDot = m_missedCallsCount ? "_note" : "";
+    QString noteDot = m_notificationCount ? "_note" : "";
 
     m_ringingState = !m_ringingState;
 
@@ -453,7 +453,7 @@ void SystemTrayMenu::resetTrayIcon()
 {
     const bool darkIconDefault =
             ThemeManager::instance().trayColorScheme() == ThemeManager::ColorScheme::DARK;
-    QString noteDot = m_missedCallsCount ? "_note" : "";
+    QString noteDot = m_notificationCount ? "_note" : "";
 
     const auto sipReg = SIPAccountManager::instance().sipRegistered();
     if (sipReg) {
@@ -479,6 +479,6 @@ void SystemTrayMenu::resetTrayIcon()
 
 void SystemTrayMenu::setBadgeNumber(unsigned number)
 {
-    m_missedCallsCount = number;
+    m_notificationCount = number;
     resetTrayIcon();
 }

--- a/src/ui/SystemTrayMenu.h
+++ b/src/ui/SystemTrayMenu.h
@@ -75,7 +75,7 @@ private:
 
     AppSettings m_settings;
 
-    unsigned m_missedCallsCount = 0;
+    unsigned m_notificationCount = 0;
 
     bool m_ringingState = false;
     bool m_hasEstablishedCalls = false;

--- a/src/ui/components/pages/BasePage.qml
+++ b/src/ui/components/pages/BasePage.qml
@@ -47,7 +47,7 @@ Item {
         target: control.tabButton
         property: "notifications"
         value: control.notifications
-        when: control.tabButton !== null
+        when: !!control.tabButton
         restoreMode: Binding.RestoreBindingOrValue
     }
 

--- a/src/ui/components/pages/BasePage.qml
+++ b/src/ui/components/pages/BasePage.qml
@@ -43,10 +43,12 @@ Item {
 
     property int notifications: widgetModel.notifications
 
-    onNotificationsChanged: () => {
-        if (control.tabButton) {
-            control.tabButton.notifications = control.notifications
-        }
+    Binding {
+        target: control.tabButton
+        property: "notifications"
+        value: control.notifications
+        when: control.tabButton !== null
+        restoreMode: Binding.RestoreBindingOrValue
     }
 
     readonly property WidgetModel model: WidgetModel {


### PR DESCRIPTION
Fixes the erratic notification reset behavior during home/call page and tab switching (the tab notification property changes to 0; this behavior might be linked to the repeater that's used to create the default tabs)