### PR TITLE
feat: plugins for microsoft calendars and contacts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ option(ENABLE_EDS "Enable EDS plugins" ON)
 option(ENABLE_LDAP "Enable LDAP plugin" ON)
 option(ENABLE_DAV "Enable DAV plugin" ON)
 option(ENABLE_CSV "Enable CSV plugin" ON)
-option(ENABLE_MSGRAPH "Enable MS Graph plugin" OFF)
+option(ENABLE_MSGRAPH "Enable MS Graph plugins" OFF)
 
 set(APP_ID "de.gonicus.gonnect")
 add_definitions(-DAPP_ID="${APP_ID}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -167,6 +167,7 @@ add_subdirectory(calendar/eds)
 add_subdirectory(contacts/akonadi)
 add_subdirectory(calendar/akonadi)
 add_subdirectory(contacts/msgraph)
+add_subdirectory(calendar/msgraph)
 
 find_package(Qt6Keychain REQUIRED)
 
@@ -348,6 +349,7 @@ qt_add_qml_module(gonnect
         ui/components/dialogs/BaseDialog.qml
         ui/components/dialogs/ConfirmDialog.qml
         ui/components/dialogs/InfoDialog.qml
+        ui/components/dialogs/OauthLoginDialog.qml
         # Dynamic UI
         ui/components/BaseWidget.qml
         ui/components/DateEventsWidget.qml
@@ -461,6 +463,8 @@ qt_add_qml_module(gonnect
         StateManager.h
         UISettings.cpp
         UISettings.h
+        MSOAuthManager.cpp
+        MSOAuthManager.h
 
         sip/CallHistory.h
         sip/CallHistory.cpp
@@ -751,6 +755,7 @@ target_link_libraries(gonnect
         ${EDS_CALENDAR_LIBRARIES}
         ${LDAP_ADDRESSBOOK_FACTORY}
         ${MSGRAPH_ADDRESSBOOK_FACTORY}
+        ${MSGRAPH_CALENDAR_FACTORY}
 )
 
 qt_import_plugins(gonnect INCLUDE
@@ -760,6 +765,7 @@ qt_import_plugins(gonnect INCLUDE
      ${CSV_ADDRESSBOOK_FACTORY}
      ${CALDAV_CALENDAR_FACTORY}
      ${MSGRAPH_ADDRESSBOOK_FACTORY}
+     ${MSGRAPH_CALENDAR_FACTORY}
      ${EDS_ADDRESSBOOK_FACTORY}
      ${EDS_CALENDAR_FACTORY}
      ${LDAP_ADDRESSBOOK_FACTORY})

--- a/src/MSOAuthManager.cpp
+++ b/src/MSOAuthManager.cpp
@@ -1,0 +1,319 @@
+#include "MSOAuthManager.h"
+#include "ReadOnlyConfdSettings.h"
+#include "Credentials.h"
+#include "ViewHelper.h"
+#include "ErrorBus.h"
+#include <QOAuth2AuthorizationCodeFlow>
+#include <QOAuthHttpServerReplyHandler>
+#include <QDesktopServices>
+#include <QLoggingCategory>
+
+Q_LOGGING_CATEGORY(msOAuthManager, "gonnect.app.MSOAuthManager")
+
+MSOAuthManager::MSOAuthManager(QObject *parent)
+    : QObject(parent), m_group(QStringLiteral("msoauth"))
+{
+}
+
+/// @brief Start OAuth login with Microsoft server, or refresh a previously successful login
+///
+/// This function attempts to load a refresh token from a previous login and use it with the
+/// Microsoft servers, or (on failure) starts displaying a UI to the user indicating that a login
+/// is required and requests user interaction.
+///
+/// @param configId The settings group of the plugin that started the login. This is used to
+///                 identify the response signal from the UI.
+/// @param reason A user visible reason for why the user should login to their Microsoft account.
+/// @param scopes The scopes to request in the OAuth request if login is needed.
+///
+void MSOAuthManager::refreshOrRequestOauthLogin(const QString &configId, const QString &reason,
+                                                const QSet<QByteArray> &scopes)
+{
+    if (m_readRefreshTokenIsOngoing) {
+        qCDebug(msOAuthManager) << "OAuth flow already ongoing. Ignoring new request.";
+        return;
+    }
+    if (m_authCodeFlow) {
+        // Check if flow is already ongoing - may happen if two plugins request login,
+        // e.g. on startup.
+        switch (m_authCodeFlow->status()) {
+        case QAbstractOAuth::Status::TemporaryCredentialsReceived:
+        case QAbstractOAuth::Status::RefreshingToken:
+            qCDebug(msOAuthManager) << "OAuth flow already ongoing. Ignoring new request.";
+            return;
+        default:
+            break;
+        }
+    }
+    m_readRefreshTokenIsOngoing = true;
+    acquireRefreshToken([this, configId, reason, scopes](const QString &token) {
+        m_readRefreshTokenIsOngoing = false;
+        if (!token.isEmpty()) {
+            initAuthCodeFlow();
+            m_authCodeFlow->setRefreshToken(token);
+            m_authCodeFlow->refreshTokens();
+        } else {
+            qCDebug(msOAuthManager) << "refreshToken not available. Require login.";
+            requestLoginInUi(configId, reason, scopes);
+        }
+    });
+}
+
+void MSOAuthManager::clearRefreshToken()
+{
+    Credentials::instance().set(
+            m_group + "/refreshToken", QString(),
+            [](QKeychain::Error error, const QString &, const QString &message) {
+                if (error != QKeychain::NoError) {
+                    ErrorBus::instance().error(
+                            tr("Failed to clear refresh token for Microsoft login: %2")
+                                    .arg(message));
+                }
+            });
+}
+
+void MSOAuthManager::requestLoginInUi(const QString &configId, const QString &reason,
+                                      const QSet<QByteArray> &scopes)
+{
+    auto &viewHelper = ViewHelper::instance();
+
+    // Remove any potentially existing connections
+    QObject::disconnect(&viewHelper, nullptr, this, nullptr);
+
+    QObject::connect(&viewHelper, &ViewHelper::oauthLoginStartResponded, this,
+                     [configId, scopes, this](const QString &id) {
+                         if (id == configId) {
+                             authorize(scopes);
+                         }
+                     });
+    QObject::connect(&viewHelper, &ViewHelper::oauthLoginCloseResponded, this,
+                     [configId, this](const QString &id) {
+                         if (id == configId) {
+                             QObject::disconnect(&ViewHelper::instance(), nullptr, this, nullptr);
+                         }
+                     });
+    m_requestConfigId = configId;
+    viewHelper.requestOauthLogin(m_requestConfigId, reason);
+}
+
+void MSOAuthManager::authStatusChanged(QAbstractOAuth::Status status)
+{
+    qCDebug(msOAuthManager) << "Microsoft auth status changed:" << static_cast<int>(status);
+    if (status == QAbstractOAuth::Status::Granted) {
+        m_replyHandler->close();
+        showOauthLoginStatus(tr("Login successful."), false);
+        Q_EMIT loginSuccessful();
+    }
+}
+
+void MSOAuthManager::initAuthCodeFlow()
+{
+    if (m_authCodeFlow) {
+        return;
+    }
+
+    ReadOnlyConfdSettings settings;
+    settings.beginGroup(m_group);
+    // The identifier of the "GOnnect" app in the microsoft backend.
+    // This should be a Gonicus registered app (see the Microsoft Entra admin center), with the
+    // redirect urls (see below) and the supported scopes configured.
+    // (A different identifier, registered by someone else, could also be used, if desired)
+    const QString clientIdentifier = settings.value("clientIdentifier").toString();
+    const QString authorizationUrl =
+            settings.value("authorizationUrl",
+                           QStringLiteral("https://login.microsoftonline.com/common/oauth2/v2.0/"
+                                          "authorize"))
+                    .toString();
+    const QString tokenUrl =
+            settings.value("authorizationUrl",
+                           QStringLiteral(
+                                   "https://login.microsoftonline.com/common/oauth2/v2.0/token"))
+                    .toString();
+
+    // For each port a redirect url must be registered in the microsoft portal for this app.
+    // http://localhost:33221/Gonnect, ...
+    const std::array<uint16_t, 3> availablePorts = { 33221, 34221, 33521 };
+
+    if (!m_replyHandler) {
+        // NOTE: Use QHostAddress::Any here.
+        //       Qt transforms "QHostAddress::Any" (and AnyIPv4 and AnyIPv6) to "localhost",
+        //       which is the only valid string atm.
+        //       NOTE: Address mutch match the address in the microsoft portal exactly.
+        m_replyHandler =
+                new QOAuthHttpServerReplyHandler(QHostAddress::Any, availablePorts[0], this);
+        //: This is text is displayed in the web browser after the user successfully logged in to the microsoft account.
+        m_replyHandler->setCallbackText(
+                tr("Login to the Microsoft account has been received by GOnnect. Gonnect will "
+                   "continue the authorization process now. You can close this page now."));
+        m_replyHandler->setCallbackPath(QStringLiteral("/Gonnect"));
+    }
+
+    if (!m_replyHandler->isListening()) {
+        // try and hope that one of the available ports is available for listening.
+        // pick the first available port.
+        for (auto port : availablePorts) {
+            if (m_replyHandler->listen(QHostAddress::Any, port)) {
+                break;
+            }
+        }
+
+        if (!m_replyHandler->isListening()) {
+            qCCritical(msOAuthManager)
+                    << "Failed to start QOAuthHttpServerReplyHandler. No port available?";
+            showOauthLoginStatus(
+                    tr("Failed to start login, the local system could not be set up to receive a "
+                       "response. Try again later.\nIf the problem persists, try to close running "
+                       "applications that reserve/block network ports."),
+                    true);
+            return;
+        }
+    }
+
+    m_authCodeFlow = new QOAuth2AuthorizationCodeFlow(this);
+    m_authCodeFlow->setReplyHandler(m_replyHandler);
+    m_authCodeFlow->setAuthorizationUrl(authorizationUrl);
+    m_authCodeFlow->setTokenUrl(tokenUrl);
+    m_authCodeFlow->setClientIdentifier(clientIdentifier);
+    m_authCodeFlow->setAutoRefresh(true);
+
+    connect(m_authCodeFlow, &QOAuth2AuthorizationCodeFlow::statusChanged, this,
+            &MSOAuthManager::authStatusChanged);
+    connect(m_authCodeFlow, &QOAuth2AuthorizationCodeFlow::authorizeWithBrowser,
+            &QDesktopServices::openUrl);
+    connect(m_authCodeFlow, &QOAuth2AuthorizationCodeFlow::serverReportedErrorOccurred, this,
+            [&](const QString &error, const QString &errorDescription, const QUrl &uri) {
+                qCInfo(msOAuthManager) << "Microsoft auth serverReportedErrorOccurred:" << error
+                                       << "description:" << errorDescription << "uri:" << uri;
+                showOauthLoginStatus(tr("Login failed, the server reported an error:\n%1\nWith "
+                                        "error description: %2")
+                                             .arg(error)
+                                             .arg(errorDescription),
+                                     true);
+            });
+    connect(m_authCodeFlow, &QOAuth2AuthorizationCodeFlow::requestFailed, this,
+            [&](const QAbstractOAuth::Error error) {
+                qCInfo(msOAuthManager)
+                        << "Microsoft auth requestFailed:" << static_cast<int>(error);
+                switch (error) {
+                case QAbstractOAuth::Error::NoError:
+                    break;
+                case QAbstractOAuth::Error::NetworkError:
+                    showOauthLoginStatus(tr("Login failed due to a network error. Check your "
+                                            "internet connectivity and try again."),
+                                         true);
+                    break;
+                case QAbstractOAuth::Error::ServerError:
+                    showOauthLoginStatus(
+                            tr("Login failed because the Microsoft server returned an unexpected "
+                               "or incorrect response. Please try again later."),
+                            true);
+                    break;
+                case QAbstractOAuth::Error::OAuthTokenNotFoundError: // fall-through intended
+                case QAbstractOAuth::Error::OAuthTokenSecretNotFoundError:
+                    showOauthLoginStatus(tr("Login failed, no token has been received."), true);
+                    break;
+                case QAbstractOAuth::Error::OAuthCallbackNotVerified:
+                    showOauthLoginStatus(
+                            tr("Login failed, possibly due to a server configuration error."),
+                            true);
+                    break;
+                case QAbstractOAuth::Error::ClientError:
+                    showOauthLoginStatus(tr("Login failed, possibly due to a GOnnect configuration "
+                                            "error. Please contact the GOnnect support."),
+                                         true);
+                    break;
+                case QAbstractOAuth::Error::ExpiredError:
+                    showOauthLoginStatus(tr("Login failed, token expired. Please try again."),
+                                         true);
+                    break;
+                default:
+                    showOauthLoginStatus(tr("Login failed, unknown error. Please try again."),
+                                         true);
+                    break;
+                }
+            });
+    connect(m_authCodeFlow, &QOAuth2AuthorizationCodeFlow::refreshTokenChanged, this,
+            [this](const QString &refreshToken) {
+                if (!refreshToken.isEmpty()) {
+                    storeRefreshToken(refreshToken);
+                }
+            });
+
+    settings.endGroup();
+}
+
+void MSOAuthManager::authorize(const QSet<QByteArray> &scopes)
+{
+    initAuthCodeFlow();
+    if (!m_authCodeFlow) {
+        return;
+    }
+    QString scopesString;
+    for (auto s : scopes) {
+        if (!scopesString.isEmpty()) {
+            scopesString += ",";
+        }
+        scopesString += s;
+    }
+    qCDebug(msOAuthManager) << "Starting microsoft authorization for scopes " << scopesString;
+    m_authCodeFlow->setRequestedScopeTokens(scopes);
+    m_authCodeFlow->grant();
+}
+
+bool MSOAuthManager::isGranted() const
+{
+    if (!m_authCodeFlow) {
+        return false;
+    }
+    return (m_authCodeFlow->status() == QAbstractOAuth::Status::Granted);
+}
+
+QString MSOAuthManager::token() const
+{
+    if (!m_authCodeFlow) {
+        return QString();
+    }
+    return m_authCodeFlow->token();
+}
+
+void MSOAuthManager::acquireRefreshToken(std::function<void(const QString &token)> callback)
+{
+    Credentials::instance().get(
+            m_group + "/refreshToken",
+            [this, callback](QKeychain::Error error, const QString &secret, const QString &) {
+                if (error == QKeychain::NoError) {
+                    if (!secret.isEmpty()) {
+                        qCDebug(msOAuthManager) << "refreshToken available for" << m_group;
+                    } else {
+                        qCDebug(msOAuthManager) << "refreshToken not available for" << m_group;
+                    }
+                } else {
+                    if (error == QKeychain::EntryNotFound) {
+                        qCDebug(msOAuthManager) << "No refreshToken found for" << m_group;
+                    } else {
+                        qCDebug(msOAuthManager)
+                                << "Error reading refreshToken for" << m_group << ":" << error;
+                    }
+                }
+                callback(secret);
+            });
+}
+
+void MSOAuthManager::storeRefreshToken(const QString &token) const
+{
+    Credentials::instance().set(
+            m_group + "/refreshToken", token,
+            [](QKeychain::Error error, const QString &, const QString &message) {
+                if (error != QKeychain::NoError) {
+                    ErrorBus::instance().error(
+                            tr("Failed to persist refresh token for Microsoft login: %2")
+                                    .arg(message));
+                }
+            });
+}
+
+void MSOAuthManager::showOauthLoginStatus(const QString &status, bool canRetry)
+{
+    auto &viewHelper = ViewHelper::instance();
+    viewHelper.showOauthLoginStatus(m_requestConfigId, status, canRetry);
+}

--- a/src/MSOAuthManager.cpp
+++ b/src/MSOAuthManager.cpp
@@ -218,7 +218,7 @@ void MSOAuthManager::initAuthCodeFlow()
                     break;
                 case QAbstractOAuth::Error::ClientError:
                     showOauthLoginStatus(tr("Login failed, possibly due to a GOnnect configuration "
-                                            "error. Please contact the GOnnect support."),
+                                            "error."),
                                          true);
                     break;
                 case QAbstractOAuth::Error::ExpiredError:

--- a/src/MSOAuthManager.cpp
+++ b/src/MSOAuthManager.cpp
@@ -248,7 +248,7 @@ void MSOAuthManager::authorize(const QSet<QByteArray> &scopes)
         return;
     }
     QString scopesString;
-    for (auto s : scopes) {
+    for (const auto &s : scopes) {
         if (!scopesString.isEmpty()) {
             scopesString += ",";
         }

--- a/src/MSOAuthManager.cpp
+++ b/src/MSOAuthManager.cpp
@@ -186,8 +186,7 @@ void MSOAuthManager::initAuthCodeFlow()
                                        << "description:" << errorDescription << "uri:" << uri;
                 showOauthLoginStatus(tr("Login failed, the server reported an error:\n%1\nWith "
                                         "error description: %2")
-                                             .arg(error)
-                                             .arg(errorDescription),
+                                             .arg(error, errorDescription),
                                      true);
             });
     connect(m_authCodeFlow, &QOAuth2AuthorizationCodeFlow::requestFailed, this,

--- a/src/MSOAuthManager.cpp
+++ b/src/MSOAuthManager.cpp
@@ -143,7 +143,7 @@ void MSOAuthManager::initAuthCodeFlow()
                 new QOAuthHttpServerReplyHandler(QHostAddress::Any, availablePorts[0], this);
         //: This is text is displayed in the web browser after the user successfully logged in to the microsoft account.
         m_replyHandler->setCallbackText(
-                tr("Login to the Microsoft account has been received by GOnnect. Gonnect will "
+                tr("Login to the Microsoft account has been received by GOnnect. GOnnect will "
                    "continue the authorization process now. You can close this page now."));
         m_replyHandler->setCallbackPath(QStringLiteral("/Gonnect"));
     }

--- a/src/MSOAuthManager.h
+++ b/src/MSOAuthManager.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <QObject>
+#include <QAbstractOAuth>
+
+class QOAuth2AuthorizationCodeFlow;
+class QOAuthHttpServerReplyHandler;
+
+/// Helper class to perform an OAuth2 login for the user to the user's Microsoft account.
+/// The login can then be used to use Microsoft APIs such as Microsoft Graph to access contacts
+/// and calendars.
+///
+/// See also https://learn.microsoft.com/en-us/entra/identity-platform/ and
+/// https://learn.microsoft.com/en-us/graph/auth/
+class MSOAuthManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    static MSOAuthManager &instance()
+    {
+        static MSOAuthManager *_instance = nullptr;
+        if (!_instance) {
+            _instance = new MSOAuthManager;
+        }
+        return *_instance;
+    }
+
+    void refreshOrRequestOauthLogin(const QString &configId, const QString &reason,
+                                    const QSet<QByteArray> &scopes);
+    void clearRefreshToken();
+
+    bool isGranted() const;
+    QString token() const;
+
+Q_SIGNALS:
+    void loginSuccessful();
+
+private:
+    explicit MSOAuthManager(QObject *parent = nullptr);
+    void acquireRefreshToken(std::function<void(const QString &token)> callback);
+    void initAuthCodeFlow();
+    void requestLoginInUi(const QString &configId, const QString &reason,
+                          const QSet<QByteArray> &scopes);
+    void authStatusChanged(QAbstractOAuth::Status status);
+    void showOauthLoginStatus(const QString &status, bool canRetry);
+    void storeRefreshToken(const QString &token) const;
+    void authorize(const QSet<QByteArray> &scopes);
+
+    const QString m_group;
+    QOAuthHttpServerReplyHandler *m_replyHandler = nullptr;
+    QOAuth2AuthorizationCodeFlow *m_authCodeFlow = nullptr;
+    QString m_requestConfigId;
+    bool m_readRefreshTokenIsOngoing = false;
+};

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -47,6 +47,7 @@ Item {
 
         property EmergencyCallIncomingWindow emergencyWindow: null
         property var passwordDialogs: ({})
+        property var oauthLoginDialogs: ({})
 
         function onActivateSearch() {
             gonnectWindow.ensureVisible()
@@ -95,6 +96,32 @@ Item {
                 dialog.Component.destruction.connect(() => delete viewHelperConnections.passwordDialogs[id])
             } else {
                 existingDialogs[id].show()
+                existingDialogs[id].raise()
+            }
+        }
+
+        function onOauthLoginRequested(id : string, reason : string) {
+            const existingDialogs = viewHelperConnections.oauthLoginDialogs
+
+            if (!existingDialogs[id]) {
+                const dialog = DialogFactory.createDialog("OauthLoginDialog.qml", { text: reason })
+                dialog.onStartOauthLogin.connect(() => ViewHelper.respondStartOauthLogin(id))
+                dialog.onCloseDialog.connect(() => ViewHelper.respondOauthLoginClosed(id))
+
+                viewHelperConnections.oauthLoginDialogs[id] = dialog
+                dialog.Component.destruction.connect(() => delete viewHelperConnections.oauthLoginDialogs[id])
+            } else {
+                existingDialogs[id].show()
+                existingDialogs[id].raise()
+            }
+        }
+
+        function onOauthLoginStatus(id : string, status : string, canRetry : bool) {
+            const dialog = viewHelperConnections.oauthLoginDialogs[id]
+            if (dialog) {
+                dialog.setStatus(status, canRetry)
+                dialog.show()
+                dialog.raise()
             }
         }
 

--- a/src/calendar/DateEventFeederManager.h
+++ b/src/calendar/DateEventFeederManager.h
@@ -25,7 +25,7 @@ public:
 
     void initFeederConfigs();
     void reload();
-    void acquireSecret(bool override, const QString &configId,
+    void acquireSecret(bool forcePrompt, const QString &configId,
                        std::function<void(const QString &secret)> callback);
 
 private:

--- a/src/calendar/msgraph/CMakeLists.txt
+++ b/src/calendar/msgraph/CMakeLists.txt
@@ -1,0 +1,28 @@
+if(ENABLE_MSGRAPH)
+    qt_add_plugin(MSGraphEventFeederFactory STATIC
+      CLASS_NAME MSGraphEventFeederFactory
+
+      MSGraphEventFeederFactory.cpp
+      MSGraphEventFeederFactory.h
+      MSGraphEventFeeder.cpp
+      MSGraphEventFeeder.h
+    )
+
+    target_include_directories(MSGraphEventFeederFactory
+      PRIVATE
+        ${PROJECT_SOURCE_DIR}/src/calendar
+        ${PROJECT_SOURCE_DIR}/src/ui
+        ${PROJECT_SOURCE_DIR}/src
+        ${PROJECT_SOURCE_DIR}
+        ${PROJECT_BINARY_DIR}/src
+    )
+
+    target_link_libraries(MSGraphEventFeederFactory PRIVATE
+      Qt6::Core
+      Qt6::Gui
+      Qt6::Quick
+      Qt6::Xml
+      Qt6::NetworkAuth)
+
+    set(MSGRAPH_CALENDAR_FACTORY MSGraphEventFeederFactory PARENT_SCOPE)
+endif()

--- a/src/calendar/msgraph/MSGraphEventFeeder.cpp
+++ b/src/calendar/msgraph/MSGraphEventFeeder.cpp
@@ -96,9 +96,6 @@ void MSGraphEventFeeder::eventsReceived(QNetworkReply *reply)
 
     DateEventManager &manager = DateEventManager::instance();
     if (m_isFirstPage) {
-        // TODO: In a more advanced variant, we could remove only the events that are no longer in
-        //       the response(s) and merely update the rest.
-        //       But for now this is good enough. We simply add all events again.
         manager.removeDateEventsBySource(eventSource);
     }
 

--- a/src/calendar/msgraph/MSGraphEventFeeder.cpp
+++ b/src/calendar/msgraph/MSGraphEventFeeder.cpp
@@ -1,0 +1,242 @@
+#include "MSGraphEventFeeder.h"
+#include "DateEventManager.h"
+#include "DateEventFeederManager.h"
+#include "ReadOnlyConfdSettings.h"
+#include "MSOAuthManager.h"
+
+#include <QLoggingCategory>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QNetworkRequestFactory>
+#include <QHttpHeaders>
+
+Q_LOGGING_CATEGORY(lcMSGraphEventFeeder, "gonnect.app.dateevents.feeder.MSGraphEventFeeder")
+
+MSGraphEventFeeder::MSGraphEventFeeder(const QString &group, const QDateTime &timeRangeStart,
+                                       const QDateTime &timeRangeEnd,
+                                       DateEventFeederManager *parent)
+    : QObject(parent),
+      m_group(group),
+      m_manager(parent),
+      m_timeRangeStart(timeRangeStart),
+      m_timeRangeEnd(timeRangeEnd)
+{
+    m_networkAccessManager = new QNetworkAccessManager(this);
+    m_calendarRefreshTimer.setSingleShot(true);
+
+    connect(&MSOAuthManager::instance(), &MSOAuthManager::loginSuccessful, this, [this]() {
+        QTimer::singleShot(std::chrono::seconds(0), this, &MSGraphEventFeeder::requestEvents);
+    });
+    connect(&m_calendarRefreshTimer, &QTimer::timeout, this, &MSGraphEventFeeder::requestEvents);
+}
+
+MSGraphEventFeeder::~MSGraphEventFeeder() { }
+
+QUrl MSGraphEventFeeder::networkCheckURL() const
+{
+    return {};
+}
+
+void MSGraphEventFeeder::init()
+{
+    if (MSOAuthManager::instance().isGranted()) {
+        requestEvents();
+    } else {
+        refreshOrRequestLogin();
+    }
+}
+
+void MSGraphEventFeeder::refreshOrRequestLogin()
+{
+    ReadOnlyConfdSettings settings;
+    QSet<QByteArray> scopes = {
+        { "offline_access" },
+#if QT_VERSION < QT_VERSION_CHECK(6, 11, 1)
+        { "openid" }, // See QTBUG-145561. Required for Qt <= 6.11 only
+#endif
+        { "Calendars.Read" },
+        { "Calendars.Read.Shared" },
+    };
+
+    // If contacts plugin is enabled as well, request calendar permissions as well at
+    // the same time
+    const auto contactsGroup = QStringLiteral("msgraphcontacts");
+    if (settings.childGroups().contains(contactsGroup)
+        && settings.value(contactsGroup + QStringLiteral("/enabled"), true).toBool()) {
+        scopes.insert({ "Contacts.Read" });
+        scopes.insert({ "Contacts.Read.Shared" });
+    }
+
+    MSOAuthManager::instance().refreshOrRequestOauthLogin(
+            m_group,
+            tr("Login to your Microsoft account is required to access your contacts or calendars "
+               "from the GOnnect application."),
+            scopes);
+}
+
+void MSGraphEventFeeder::eventsReceived(QNetworkReply *reply)
+{
+    if (!reply) {
+        return;
+    }
+    reply->deleteLater();
+    if (reply->error() != QNetworkReply::NoError) {
+        return;
+    }
+
+    auto jsonText = reply->readAll();
+    auto doc = QJsonDocument::fromJson(jsonText);
+    if (doc.isNull()) {
+        return;
+    }
+
+    const QString eventSource = m_group;
+
+    DateEventManager &manager = DateEventManager::instance();
+    if (m_isFirstPage) {
+        // TODO: In a more advanced variant, we could remove only the events that are no longer in
+        //       the response(s) and merely update the rest.
+        //       But for now this is good enough. We simply add all events again.
+        manager.removeDateEventsBySource(eventSource);
+    }
+
+    auto value = doc.object()["value"];
+    auto events = value.toArray();
+    for (const auto &event : events) {
+        const auto obj = event.toObject();
+        if (!obj.contains("id") || !obj.contains("start") || !obj.contains("end")
+            || !obj.contains("subject")) {
+            qCWarning(lcMSGraphEventFeeder) << "Invalid event format encountered";
+            continue;
+        }
+        if (obj.contains("isCancelled") && obj["isCancelled"].toBool()) {
+            continue;
+        }
+        const auto eventId = obj["id"].toString();
+        const QDateTime start = parseDateTime(obj["start"]);
+        const QDateTime end = parseDateTime(obj["end"]);
+        if (!start.isValid() || !end.isValid()) {
+            qCCritical(lcMSGraphEventFeeder)
+                    << "Error parsing start or end datetime for event" << eventId
+                    << "start:" << obj["start"].toString() << "end:" << obj["end"].toString();
+            continue;
+        }
+        const auto subject = obj["subject"].toString();
+        QString location;
+        if (obj.contains("location") && obj["location"].isObject()) {
+            location = obj["location"].toObject()["displayName"].toString();
+        }
+        // Alternatively,we could use obj["body"].toObject()["content"].toString(), however this
+        // is likely in HTML (see obj["body"].toObject()["contentType"].toString())
+        const auto bodyPreview = obj["bodyPreview"].toString();
+
+        manager.addDateEvent(eventId, eventSource, start, end, subject, location, bodyPreview);
+    }
+
+    m_isFirstPage = false;
+    if (doc.object().contains("@odata.nextLink")) {
+        QString nextLink = doc.object()["@odata.nextLink"].toString();
+
+        using namespace Qt::StringLiterals;
+        QNetworkRequest request(nextLink);
+        QHttpHeaders headers;
+        headers.append(QHttpHeaders::WellKnownHeader::Authorization,
+                       u"Bearer "_s + MSOAuthManager::instance().token());
+        request.setHeaders(headers);
+        auto *reply = m_networkAccessManager->get(request);
+        connect(reply, &QNetworkReply::finished, this, [this, reply]() { eventsReceived(reply); });
+        connect(reply, &QNetworkReply::errorOccurred, this,
+                [this, reply](QNetworkReply::NetworkError code) { errorOccurred(reply, code); });
+    } else {
+        ReadOnlyConfdSettings settings;
+        m_calendarRefreshTimer.setInterval(settings.value("interval", 900000).toInt());
+        m_calendarRefreshTimer.start();
+    }
+}
+
+void MSGraphEventFeeder::requestEvents()
+{
+    m_calendarRefreshTimer.stop();
+    if (!MSOAuthManager::instance().isGranted()) {
+        qCWarning(lcMSGraphEventFeeder) << "Cannot request events - not logged in";
+        return;
+    }
+    if (!m_timeRangeStart.isValid() || !m_timeRangeEnd.isValid()) {
+        qCWarning(lcMSGraphEventFeeder) << "Cannot request events - timerange not valid";
+        return;
+    }
+
+    qCDebug(lcMSGraphEventFeeder) << "Requesting events with microsoft graph api";
+
+    QNetworkRequestFactory requestFactory({ "https://graph.microsoft.com/v1.0" });
+    requestFactory.setBearerToken(MSOAuthManager::instance().token().toLatin1());
+
+    // NOTE: timerange is required for calendarview requests. Must be in ISO-8601 format
+    //       ("2026-04-21T14:21:51.565Z")
+    auto request = requestFactory.createRequest(QStringLiteral("me/calendarview?startdatetime=")
+                                                + m_timeRangeStart.toString(Qt::ISODate)
+                                                + QStringLiteral("&enddatetime=")
+                                                + m_timeRangeEnd.toString(Qt::ISODate));
+    auto *reply = m_networkAccessManager->get(request);
+    if (!reply) {
+        qCCritical(lcMSGraphEventFeeder) << "Failed to create contacts request";
+        return;
+    }
+
+    m_isFirstPage = true;
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() { eventsReceived(reply); });
+    connect(reply, &QNetworkReply::errorOccurred, this,
+            [this, reply](QNetworkReply::NetworkError code) { errorOccurred(reply, code); });
+}
+
+void MSGraphEventFeeder::errorOccurred(QNetworkReply *reply, QNetworkReply::NetworkError code)
+{
+    if (!reply) {
+        return;
+    }
+    m_calendarRefreshTimer.stop();
+    switch (code) {
+    case QNetworkReply::NoError:
+        // Should never happen here
+        break;
+    // See msgraph API documentation: HTTP status code 401 (Unauthorized) and 403 (Forbidden)
+    // may indicate issues with the login.
+    case QNetworkReply::AuthenticationRequiredError: // Corresponds to HTTP 401
+    case QNetworkReply::ContentAccessDenied: // Corresponds to HTTP 403
+        qCCritical(lcMSGraphEventFeeder)
+                << "Network error for msgraph request:" << code << "require new login to account.";
+        MSOAuthManager::instance()
+                .clearRefreshToken(); // Make sure we don't try to refresh the token again
+        refreshOrRequestLogin();
+        break;
+    default:
+        qCCritical(lcMSGraphEventFeeder) << "Network error for msgraph request:" << code;
+        break;
+    }
+    reply->deleteLater();
+}
+
+QDateTime MSGraphEventFeeder::parseDateTime(const QJsonValue &dateTimeContainer)
+{
+    if (!dateTimeContainer.isObject()) {
+        return QDateTime();
+    }
+    const auto obj = dateTimeContainer.toObject();
+    // Container have a "dateTime" and a "timeZone" key.
+    // We only need dateTime: timeZone is UTC in responses, if nothing else was requested.
+    if (!obj.contains("dateTime")) {
+        return QDateTime();
+    }
+    auto s = obj["dateTime"].toString();
+    // Epected format: "2026-03-20T17:00:00.0000000"
+    // we only need up to 3 digits after the decimal point (=ms precision) and we need a 'Z'
+    // afterwards, for Qt to recognize UTC.
+    if (s.length() < 23) {
+        return QDateTime();
+    }
+    s = s.left(23) + QStringLiteral("Z");
+    return QDateTime::fromString(s, QStringLiteral("yyyy-MM-ddTHH:mm:ss.zzzt"));
+}

--- a/src/calendar/msgraph/MSGraphEventFeeder.cpp
+++ b/src/calendar/msgraph/MSGraphEventFeeder.cpp
@@ -27,9 +27,8 @@ MSGraphEventFeeder::MSGraphEventFeeder(const QString &group, const QDateTime &ti
     m_networkAccessManager = new QNetworkAccessManager(this);
     m_calendarRefreshTimer.setSingleShot(true);
 
-    connect(&MSOAuthManager::instance(), &MSOAuthManager::loginSuccessful, this, [this]() {
-        QTimer::singleShot(std::chrono::seconds(0), this, &MSGraphEventFeeder::requestEvents);
-    });
+    connect(&MSOAuthManager::instance(), &MSOAuthManager::loginSuccessful, this,
+            &MSGraphEventFeeder::requestEvents);
     connect(&m_calendarRefreshTimer, &QTimer::timeout, this, &MSGraphEventFeeder::requestEvents);
 }
 

--- a/src/calendar/msgraph/MSGraphEventFeeder.cpp
+++ b/src/calendar/msgraph/MSGraphEventFeeder.cpp
@@ -72,7 +72,7 @@ void MSGraphEventFeeder::refreshOrRequestLogin()
     MSOAuthManager::instance().refreshOrRequestOauthLogin(
             m_group,
             tr("Login to your Microsoft account is required to access your contacts or calendars "
-               "from the GOnnect application."),
+               "from GOnnect."),
             scopes);
 }
 

--- a/src/calendar/msgraph/MSGraphEventFeeder.h
+++ b/src/calendar/msgraph/MSGraphEventFeeder.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <QObject>
+#include <QDateTime>
+#include <QNetworkReply>
+#include <QTimer>
+
+#include "IDateEventFeeder.h"
+
+class QJsonValue;
+class DateEventFeederManager;
+
+class MSGraphEventFeeder : public QObject, public IDateEventFeeder
+{
+    Q_OBJECT
+
+public:
+    explicit MSGraphEventFeeder(const QString &group, const QDateTime &timeRangeStart,
+                                const QDateTime &timeRangeEnd,
+                                DateEventFeederManager *parent = nullptr);
+    ~MSGraphEventFeeder();
+
+    void init() override;
+    QUrl networkCheckURL() const override;
+
+private Q_SLOTS:
+    void requestEvents();
+
+private:
+    void refreshOrRequestLogin();
+    void eventsReceived(QNetworkReply *reply);
+    void errorOccurred(QNetworkReply *reply, QNetworkReply::NetworkError code);
+    static QDateTime parseDateTime(const QJsonValue &dateTimeContainer);
+
+    const QString m_group;
+    const QDateTime m_timeRangeStart;
+    const QDateTime m_timeRangeEnd;
+    DateEventFeederManager *m_manager = nullptr;
+    QNetworkAccessManager *m_networkAccessManager = nullptr;
+    QTimer m_calendarRefreshTimer;
+    bool m_isFirstPage = true;
+};

--- a/src/calendar/msgraph/MSGraphEventFeederFactory.cpp
+++ b/src/calendar/msgraph/MSGraphEventFeederFactory.cpp
@@ -1,0 +1,34 @@
+#include "MSGraphEventFeederFactory.h"
+#include "ReadOnlyConfdSettings.h"
+#include "MSGraphEventFeeder.h"
+#include "DateEventFeederManager.h"
+
+MSGraphEventFeederFactory::MSGraphEventFeederFactory(QObject *parent) : QObject{ parent } { }
+
+QStringList MSGraphEventFeederFactory::configurations() const
+{
+    QStringList res;
+
+    ReadOnlyConfdSettings settings;
+    const auto msOAuthGroup = QStringLiteral("msoauth");
+    const auto group = QStringLiteral("msgraphcalendar");
+    if (settings.childGroups().contains(msOAuthGroup) && settings.childGroups().contains(group)) {
+        const auto &clientIdentifier =
+                settings.value(msOAuthGroup + QStringLiteral("/clientIdentifier")).toString();
+        const bool enabled = settings.value(group + QStringLiteral("enabled"), true).toBool();
+
+        if (enabled && !clientIdentifier.isEmpty()) {
+            res.push_back(group);
+        }
+    }
+
+    return res;
+}
+
+IDateEventFeeder *MSGraphEventFeederFactory::createFeeder(
+        const QString &settingsGroup, const QDateTime &currentTime, const QDateTime &timeRangeStart,
+        const QDateTime &timeRangeEnd, DateEventFeederManager *feederManager) const
+{
+    Q_UNUSED(currentTime);
+    return new MSGraphEventFeeder(settingsGroup, timeRangeStart, timeRangeEnd, feederManager);
+}

--- a/src/calendar/msgraph/MSGraphEventFeederFactory.h
+++ b/src/calendar/msgraph/MSGraphEventFeederFactory.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "IDateEventFeederFactory.h"
+
+#include <QObject>
+
+class MSGraphEventFeederFactory : public QObject, IDateEventFeederFactory
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "MSGraphEventFeederFactory" URI
+                          "de.gonicus.gonnect.MSGraphEventFeederFactory")
+    Q_INTERFACES(IDateEventFeederFactory)
+
+public:
+    MSGraphEventFeederFactory(QObject *parent = nullptr);
+
+    QString name() const override { return "MSGraphCalendar"; };
+    QStringList configurations() const override;
+    IDateEventFeeder *createFeeder(const QString &settingsGroup, const QDateTime &currentTime,
+                                   const QDateTime &timeRangeStart, const QDateTime &timeRangeEnd,
+                                   DateEventFeederManager *feederManager) const override;
+};

--- a/src/contacts/msgraph/CMakeLists.txt
+++ b/src/contacts/msgraph/CMakeLists.txt
@@ -11,9 +11,7 @@ if(ENABLE_MSGRAPH)
     target_include_directories(MSGraphAddressBookFactory
       PRIVATE
         ${PROJECT_SOURCE_DIR}/src/contacts
-        ${PROJECT_SOURCE_DIR}/src/dbus/portal
         ${PROJECT_SOURCE_DIR}/src/ui
-        ${PROJECT_SOURCE_DIR}/src/sip
         ${PROJECT_SOURCE_DIR}/src
         ${PROJECT_SOURCE_DIR}
         ${PROJECT_BINARY_DIR}/src

--- a/src/contacts/msgraph/MSGraphAddressBookFactory.cpp
+++ b/src/contacts/msgraph/MSGraphAddressBookFactory.cpp
@@ -6,20 +6,16 @@ QStringList MSGraphAddressBookFactory::configurations() const
 {
     QStringList res;
 
-    static QRegularExpression groupRegex = QRegularExpression("^msgraph[0-9]+$");
-
     ReadOnlyConfdSettings settings;
-    const QStringList groups = settings.childGroups();
+    const auto msOAuthGroup = QStringLiteral("msoauth");
+    const auto group = QStringLiteral("msgraphcontacts");
+    if (settings.childGroups().contains(msOAuthGroup) && settings.childGroups().contains(group)) {
+        const auto &clientIdentifier =
+                settings.value(msOAuthGroup + QStringLiteral("/clientIdentifier")).toString();
+        const bool enabled = settings.value(group + QStringLiteral("enabled"), true).toBool();
 
-    for (const auto &group : groups) {
-        if (groupRegex.match(group).hasMatch()) {
-            settings.beginGroup(group);
-            const bool enabled = settings.value("enabled", true).toBool();
-            settings.endGroup();
-
-            if (enabled) {
-                res.push_back(group);
-            }
+        if (enabled && !clientIdentifier.isEmpty()) {
+            res.push_back(group);
         }
     }
 

--- a/src/contacts/msgraph/MSGraphAddressBookFactory.h
+++ b/src/contacts/msgraph/MSGraphAddressBookFactory.h
@@ -14,7 +14,7 @@ class MSGraphAddressBookFactory : public QObject, IAddressBookFactory
 public:
     MSGraphAddressBookFactory() { };
 
-    QString name() const override { return "MSGraph"; }
+    QString name() const override { return "MSGraphContacts"; }
 
     QStringList configurations() const override;
 

--- a/src/contacts/msgraph/MSGraphAddressBookFeeder.cpp
+++ b/src/contacts/msgraph/MSGraphAddressBookFeeder.cpp
@@ -11,7 +11,6 @@
 #include <QNetworkReply>
 #include <QNetworkRequestFactory>
 #include <QHttpHeaders>
-#include <QTimer>
 
 Q_LOGGING_CATEGORY(msGraphAddressBookFeeder, "gonnect.app.feeder.MSGraphAddressBookFeeder")
 
@@ -20,9 +19,8 @@ MSGraphAddressBookFeeder::MSGraphAddressBookFeeder(const QString &group, Address
 {
     m_networkAccessManager = new QNetworkAccessManager(this);
 
-    connect(&MSOAuthManager::instance(), &MSOAuthManager::loginSuccessful, this, [this]() {
-        QTimer::singleShot(std::chrono::seconds(0), this, [this]() { requestContacts(); });
-    });
+    connect(&MSOAuthManager::instance(), &MSOAuthManager::loginSuccessful, this,
+            &MSGraphAddressBookFeeder::requestContacts);
 }
 
 QUrl MSGraphAddressBookFeeder::networkCheckURL() const

--- a/src/contacts/msgraph/MSGraphAddressBookFeeder.cpp
+++ b/src/contacts/msgraph/MSGraphAddressBookFeeder.cpp
@@ -207,6 +207,6 @@ void MSGraphAddressBookFeeder::refreshOrRequestLogin()
     MSOAuthManager::instance().refreshOrRequestOauthLogin(
             m_group,
             tr("Login to your Microsoft account is required to access your contacts or calendars "
-               "from the GOnnect application."),
+               "from GOnnect."),
             scopes);
 }

--- a/src/contacts/msgraph/MSGraphAddressBookFeeder.cpp
+++ b/src/contacts/msgraph/MSGraphAddressBookFeeder.cpp
@@ -1,18 +1,17 @@
 #include "MSGraphAddressBookFeeder.h"
 #include "AddressBook.h"
 #include "AddressBookManager.h"
-#include "AvatarManager.h"
 #include "ReadOnlyConfdSettings.h"
-#include <QOAuthHttpServerReplyHandler>
-#include <QRegularExpression>
-#include <QDesktopServices>
+#include "MSOAuthManager.h"
 #include <QLoggingCategory>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
+#include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequestFactory>
 #include <QHttpHeaders>
+#include <QTimer>
 
 Q_LOGGING_CATEGORY(msGraphAddressBookFeeder, "gonnect.app.feeder.MSGraphAddressBookFeeder")
 
@@ -20,6 +19,10 @@ MSGraphAddressBookFeeder::MSGraphAddressBookFeeder(const QString &group, Address
     : QObject(parent), m_manager(parent), m_group(group)
 {
     m_networkAccessManager = new QNetworkAccessManager(this);
+
+    connect(&MSOAuthManager::instance(), &MSOAuthManager::loginSuccessful, this, [this]() {
+        QTimer::singleShot(std::chrono::seconds(0), this, [this]() { requestContacts(); });
+    });
 }
 
 QUrl MSGraphAddressBookFeeder::networkCheckURL() const
@@ -27,16 +30,12 @@ QUrl MSGraphAddressBookFeeder::networkCheckURL() const
     return {};
 }
 
-void MSGraphAddressBookFeeder::authStatusChanged(QAbstractOAuth::Status status)
-{
-    if (status == QAbstractOAuth::Status::Granted) {
-        m_replyHandler->close();
-        QTimer::singleShot(std::chrono::seconds(0), this, [this]() { requestContacts(); });
-    }
-}
-
 void MSGraphAddressBookFeeder::contactsReceived(QNetworkReply *reply)
 {
+    if (!reply) {
+        return;
+    }
+    reply->deleteLater();
     if (reply->error() != QNetworkReply::NoError) {
         return;
     }
@@ -50,7 +49,7 @@ void MSGraphAddressBookFeeder::contactsReceived(QNetworkReply *reply)
     auto value = doc.object()["value"];
     auto contacts = value.toArray();
     auto &addressBook = AddressBook::instance();
-    for (auto contact : contacts) {
+    for (const auto &contact : contacts) {
         const auto obj = contact.toObject();
 
         const auto contactId = obj["id"].toString();
@@ -117,17 +116,45 @@ void MSGraphAddressBookFeeder::contactsReceived(QNetworkReply *reply)
         QNetworkRequest request(nextLink);
         QHttpHeaders headers;
         headers.append(QHttpHeaders::WellKnownHeader::Authorization,
-                       u"Bearer "_s + m_authCodeFlow->token());
+                       u"Bearer "_s + MSOAuthManager::instance().token());
         request.setHeaders(headers);
         auto *reply = m_networkAccessManager->get(request);
         connect(reply, &QNetworkReply::finished, reply,
                 [this, reply]() { contactsReceived(reply); });
+        connect(reply, &QNetworkReply::errorOccurred, this,
+                [this, reply](QNetworkReply::NetworkError code) { errorOccurred(reply, code); });
     }
+}
+
+void MSGraphAddressBookFeeder::errorOccurred(QNetworkReply *reply, QNetworkReply::NetworkError code)
+{
+    if (!reply) {
+        return;
+    }
+    switch (code) {
+    case QNetworkReply::NoError:
+        // Should never happen here
+        break;
+    // See msgraph API documentation: HTTP status code 401 (Unauthorized) and 403 (Forbidden)
+    // may indicate issues with the login.
+    case QNetworkReply::AuthenticationRequiredError: // Corresponds to HTTP 401
+    case QNetworkReply::ContentAccessDenied: // Corresponds to HTTP 403
+        qCCritical(msGraphAddressBookFeeder)
+                << "Network error for msgraph request:" << code << "require new login to account.";
+        MSOAuthManager::instance()
+                .clearRefreshToken(); // Make sure we don't try to refresh the token again
+        refreshOrRequestLogin();
+        break;
+    default:
+        qCCritical(msGraphAddressBookFeeder) << "Network error for msgraph request:" << code;
+        break;
+    }
+    reply->deleteLater();
 }
 
 void MSGraphAddressBookFeeder::requestContacts()
 {
-    if (!m_authCodeFlow || m_authCodeFlow->status() != QAbstractOAuth::Status::Granted) {
+    if (!MSOAuthManager::instance().isGranted()) {
         qCWarning(msGraphAddressBookFeeder) << "Cannot request contacts - not logged in";
         return;
     }
@@ -135,7 +162,7 @@ void MSGraphAddressBookFeeder::requestContacts()
     qCDebug(msGraphAddressBookFeeder) << "Requesting contacts with microsoft graph api";
 
     QNetworkRequestFactory requestFactory({ "https://graph.microsoft.com/v1.0" });
-    requestFactory.setBearerToken(m_authCodeFlow->token().toLatin1());
+    requestFactory.setBearerToken(MSOAuthManager::instance().token().toLatin1());
 
     auto request = requestFactory.createRequest("me/contacts");
     auto *reply = m_networkAccessManager->get(request);
@@ -145,60 +172,43 @@ void MSGraphAddressBookFeeder::requestContacts()
     }
 
     connect(reply, &QNetworkReply::finished, reply, [this, reply]() { contactsReceived(reply); });
-}
-
-void MSGraphAddressBookFeeder::authorize()
-{
-    qCDebug(msGraphAddressBookFeeder) << "Starting microsoft authorization";
-    if (!m_replyHandler) {
-        m_replyHandler = new QOAuthHttpServerReplyHandler(this);
-    }
-
-    if (!m_replyHandler->isListening()) {
-        // For each port a redirect url must be registered in the azure portal for this app.
-        // http://127.0.0.1:33221 ...
-        std::array<uint16_t, 3> availablePorts = { 33221, 34221, 33521 };
-
-        // try and hope that one of the available ports is available for listening
-        for (auto port : availablePorts) {
-            if (m_replyHandler->listen(QHostAddress::Any, port)) {
-                break;
-            }
-        }
-
-        if (!m_replyHandler->isListening()) {
-            qCCritical(msGraphAddressBookFeeder)
-                    << "Failed to start QOAuthHttpServerReplyHandler. No port available?";
-            return;
-        }
-    }
-
-    if (!m_authCodeFlow) {
-        const QSet<QByteArray> tokens = { { "Contacts.Read" } };
-        m_authCodeFlow = new QOAuth2AuthorizationCodeFlow(this);
-        m_authCodeFlow->setReplyHandler(m_replyHandler);
-        m_authCodeFlow->setAuthorizationUrl(
-                QStringLiteral("https://login.microsoftonline.com/common/oauth2/v2.0/authorize"));
-        m_authCodeFlow->setTokenUrl(
-                { "https://login.microsoftonline.com/common/oauth2/v2.0/token" });
-        m_authCodeFlow->setRequestedScopeTokens(tokens);
-        m_authCodeFlow->setClientIdentifier(QStringLiteral("040bd189-3f48-414d-acf8-076bf1983326"));
-
-        connect(m_authCodeFlow, &QOAuth2AuthorizationCodeFlow::statusChanged, this,
-                &MSGraphAddressBookFeeder::authStatusChanged);
-
-        connect(m_authCodeFlow, &QOAuth2AuthorizationCodeFlow::authorizeWithBrowser,
-                &QDesktopServices::openUrl);
-    }
-
-    m_authCodeFlow->grant();
+    connect(reply, &QNetworkReply::errorOccurred, this,
+            [this, reply](QNetworkReply::NetworkError code) { errorOccurred(reply, code); });
 }
 
 void MSGraphAddressBookFeeder::process()
 {
-    if (m_authCodeFlow && m_authCodeFlow->status() == QAbstractOAuth::Status::Granted) {
+    if (MSOAuthManager::instance().isGranted()) {
         requestContacts();
     } else {
-        authorize();
+        refreshOrRequestLogin();
     }
+}
+
+void MSGraphAddressBookFeeder::refreshOrRequestLogin()
+{
+    ReadOnlyConfdSettings settings;
+    QSet<QByteArray> scopes = {
+        { "offline_access" },
+#if QT_VERSION < QT_VERSION_CHECK(6, 11, 1)
+        { "openid" }, // See QTBUG-145561. Required for Qt <= 6.11 only
+#endif
+        { "Contacts.Read" },
+        { "Contacts.Read.Shared" },
+    };
+
+    // If calendar plugin is enabled as well, request calendar permissions as well at
+    // the same time
+    const auto calendarGroup = QStringLiteral("msgraphcalendar");
+    if (settings.childGroups().contains(calendarGroup)
+        && settings.value(calendarGroup + QStringLiteral("/enabled"), true).toBool()) {
+        scopes.insert({ "Calendars.Read" });
+        scopes.insert({ "Calendars.Read.Shared" });
+    }
+
+    MSOAuthManager::instance().refreshOrRequestOauthLogin(
+            m_group,
+            tr("Login to your Microsoft account is required to access your contacts or calendars "
+               "from the GOnnect application."),
+            scopes);
 }

--- a/src/contacts/msgraph/MSGraphAddressBookFeeder.h
+++ b/src/contacts/msgraph/MSGraphAddressBookFeeder.h
@@ -1,14 +1,12 @@
 #pragma once
 
 #include <QObject>
+#include <QNetworkReply>
 #include <IAddressBookFeeder.h>
-#include <QOAuth2AuthorizationCodeFlow>
-#include <QNetworkAccessManager>
 #include "Contact.h"
 
 class AddressBook;
 class AddressBookManager;
-class QOAuthHttpServerReplyHandler;
 
 class MSGraphAddressBookFeeder : public QObject, public IAddressBookFeeder
 {
@@ -21,21 +19,12 @@ public:
     QUrl networkCheckURL() const override;
 
 private:
-    void authStatusChanged(QAbstractOAuth::Status status);
-
+    void refreshOrRequestLogin();
     void contactsReceived(QNetworkReply *reply);
-
+    void errorOccurred(QNetworkReply *reply, QNetworkReply::NetworkError code);
     void requestContacts();
 
-    void authorize();
-
+    const QString m_group;
     AddressBookManager *m_manager = nullptr;
-
-    QOAuthHttpServerReplyHandler *m_replyHandler = nullptr;
-
-    QString m_group;
-
-    QOAuth2AuthorizationCodeFlow *m_authCodeFlow = nullptr;
-
     QNetworkAccessManager *m_networkAccessManager = nullptr;
 };

--- a/src/ui/ViewHelper.cpp
+++ b/src/ui/ViewHelper.cpp
@@ -359,6 +359,26 @@ void ViewHelper::respondPassword(const QString &id, const QString password)
     Q_EMIT passwordResponded(id, password);
 }
 
+void ViewHelper::requestOauthLogin(const QString &id, const QString &reason)
+{
+    Q_EMIT oauthLoginRequested(id, reason);
+}
+
+void ViewHelper::respondStartOauthLogin(const QString &id)
+{
+    Q_EMIT oauthLoginStartResponded(id);
+}
+
+void ViewHelper::showOauthLoginStatus(const QString &id, const QString &status, bool canRetry)
+{
+    Q_EMIT oauthLoginStatus(id, status, canRetry);
+}
+
+void ViewHelper::respondOauthLoginClosed(const QString &id)
+{
+    Q_EMIT oauthLoginCloseResponded(id);
+}
+
 void ViewHelper::respondRecoveryKey(const QString &id, const QString &key)
 {
     Q_EMIT recoveryKeyResponded(id, key);

--- a/src/ui/ViewHelper.h
+++ b/src/ui/ViewHelper.h
@@ -99,6 +99,11 @@ public:
     void requestPassword(const QString &id, const QString &host);
     Q_INVOKABLE void respondPassword(const QString &id, const QString password);
 
+    void requestOauthLogin(const QString &id, const QString &reason);
+    Q_INVOKABLE void respondStartOauthLogin(const QString &id);
+    void showOauthLoginStatus(const QString &id, const QString &status, bool canRetry);
+    Q_INVOKABLE void respondOauthLoginClosed(const QString &id);
+
     void requestRecoveryKey(const QString &id, const QString &displayName);
     Q_INVOKABLE void respondRecoveryKey(const QString &id, const QString &key);
 
@@ -186,6 +191,11 @@ Q_SIGNALS:
 
     void passwordRequested(QString id, QString host);
     void passwordResponded(QString id, QString password);
+
+    void oauthLoginRequested(QString id, QString reason);
+    void oauthLoginStartResponded(QString id);
+    void oauthLoginStatus(QString id, QString status, bool canRetry);
+    void oauthLoginCloseResponded(QString id);
 
     void recoveryKeyRequested(QString id, QString displayName);
     void recoveryKeyResponded(QString id, QString key);

--- a/src/ui/components/dialogs/OauthLoginDialog.qml
+++ b/src/ui/components/dialogs/OauthLoginDialog.qml
@@ -34,7 +34,7 @@ BaseDialog {
 
     Label {
         id: flowLabel
-        text: qsTr("To begin the login, press start. A browser window will open asking you to login to your account and share the required data with Gonnect.")
+        text: qsTr("To begin the login, press 'Authenticate'. A browser window will open asking you to login to your account and share the required data with GOnnect.")
         elide: Label.ElideRight
         wrapMode: Label.WordWrap
         anchors {
@@ -50,7 +50,7 @@ BaseDialog {
 
     Button {
         id: startButton
-        text: qsTr("Start")
+        text: qsTr("Authenticate")
         highlighted: true
         anchors {
             top: flowLabel.bottom

--- a/src/ui/components/dialogs/OauthLoginDialog.qml
+++ b/src/ui/components/dialogs/OauthLoginDialog.qml
@@ -1,0 +1,115 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls.Material
+import base
+
+BaseDialog {
+    id: control
+    title: qsTr("Login required")
+
+    signal startOauthLogin()
+    signal closeDialog()
+
+    property alias text: contentLabel.text
+    property alias statusText: statusLabel.text
+    height: 454
+
+    Label {
+        id: contentLabel
+        text: ""
+        elide: Label.ElideRight
+        wrapMode: Label.WordWrap
+        anchors {
+            top: parent.top
+            left: parent.left
+            right: parent.right
+            margins: 20
+        }
+
+        Accessible.role: Accessible.StaticText
+        Accessible.name: control.title + ", " + contentLabel.text
+    }
+
+    Label {
+        id: flowLabel
+        text: qsTr("To begin the login, press start. A browser window will open asking you to login to your account and share the required data with Gonnect.")
+        elide: Label.ElideRight
+        wrapMode: Label.WordWrap
+        anchors {
+            top: contentLabel.bottom
+            left: parent.left
+            right: parent.right
+            margins: 20
+        }
+
+        Accessible.role: Accessible.StaticText
+        Accessible.name: control.title + ", " + flowLabel.text
+    }
+
+    Button {
+        id: startButton
+        text: qsTr("Start")
+        highlighted: true
+        anchors {
+            top: flowLabel.bottom
+            horizontalCenter: parent.horizontalCenter
+            margins: 20
+        }
+
+        onClicked: () => {
+            startButton.enabled = false
+            control.startOauthLogin()
+        }
+
+        Accessible.role: Accessible.Button
+        Accessible.name: startButton.text
+        Accessible.focusable: true
+        Accessible.onPressAction: () => startButton.click()
+    }
+
+    Label {
+        id: statusLabel
+        text: ""
+        visible: false
+        elide: Label.ElideRight
+        wrapMode: Label.WordWrap
+        anchors {
+            top: startButton.bottom
+            left: parent.left
+            right: parent.right
+            margins: 20
+        }
+    }
+
+    Button {
+        id: closeButton
+        text: qsTr("Close")
+        anchors {
+            bottom: parent.bottom
+            right: parent.right
+            bottomMargin: 5
+            rightMargin: 10
+        }
+
+        onClicked: () => {
+            closeButton.enabled = false
+            control.closeDialog()
+            control.close()
+        }
+
+        Accessible.role: Accessible.Button
+        Accessible.name: closeButton.text
+        Accessible.focusable: true
+        Accessible.onPressAction: () => closeButton.click()
+    }
+
+    function setStatus(status : string, canRetry: bool) {
+        startButton.enabled = true
+        statusLabel.text = status
+        statusLabel.visible = true
+        startButton.visible = canRetry
+        flowLabel.visible = canRetry
+    }
+}


### PR DESCRIPTION
Both plugins use the msgraph API over OAuth.
The existing contacts plugin is improved and extended, the calendar plugin is newly added with a similar approach to the contacts plugin.

The OAuth code for the microsoft login is refactored out of the plugins, so that we can use the same login for both plugins.

A basic UI is introduced for the OAuth login, that can be re-used for other OAuths, if needed. This is in particular needed to inform the user *why* a browser window is being opened that requests a login from the user (and also to tell the user when an error occurred).

Various improvements:
- More logging during authorization
- Make clientIdentifier and URLs configurable
- Use custom string in the browser message on authorization success
- Use explicit /Gonnect path in the redirect url
- Adding a basic GUI to login to msgraph
- Persist refresh token and use it on startup