### PR TITLE
fix: do not wipe all contact sources on by-source removals

### DIFF
--- a/src/contacts/AddressBook.cpp
+++ b/src/contacts/AddressBook.cpp
@@ -156,14 +156,26 @@ void AddressBook::removeContactsBySource(const QString &source)
 {
     QMutexLocker lock(&m_feederMutex);
 
+    QString sourceUid;
+    bool sourceInfoCleared = false;
     for (auto contact : std::as_const(m_contacts)) {
         if (contact->contactSourceInfo().configId == source) {
+            sourceUid = contact->sourceUid();
+
+            // Remove the ContactSourceInfo of the contact source
+            if (!sourceInfoCleared) {
+                m_contactSourceInfos.removeAll(contact->contactSourceInfo());
+                sourceInfoCleared = true;
+
+                Q_EMIT contactSourceInfosChanged();
+            }
+
             m_contacts.remove(contact->id());
-            m_contactsBySourceId.remove(contact->sourceUid());
+            m_contactsBySourceId.remove(sourceUid);
+
+            Q_EMIT contactRemoved(sourceUid);
         }
     }
-
-    Q_EMIT contactsCleared();
 }
 
 QHash<QString, Contact *> AddressBook::contacts() const

--- a/src/contacts/Contact.cpp
+++ b/src/contacts/Contact.cpp
@@ -406,5 +406,6 @@ bool Contact::ContactSourceInfo::operator==(const ContactSourceInfo &other) cons
 
 bool Contact::ContactSourceInfo::operator!=(const ContactSourceInfo &other) const
 {
-    return this->prio != other.prio || this->displayName != other.displayName;
+    return this->prio != other.prio || this->displayName != other.displayName
+            || this->configId != other.configId;
 }

--- a/src/contacts/akonadi/AkonadiAddressBookFeeder.cpp
+++ b/src/contacts/akonadi/AkonadiAddressBookFeeder.cpp
@@ -28,7 +28,7 @@ AkonadiAddressBookFeeder::AkonadiAddressBookFeeder(const QString &group, const i
     ReadOnlyConfdSettings settings;
 
     settings.beginGroup(m_group);
-    m_displayName = settings.value("displayName", "").toString();
+    m_displayName = settings.value("displayName", m_group).toString();
     bool ok = true;
     m_priority = settings.value("prio", 0).toUInt(&ok);
     if (!ok) {

--- a/src/contacts/carddav/CardDAVAddressBookFeeder.cpp
+++ b/src/contacts/carddav/CardDAVAddressBookFeeder.cpp
@@ -365,7 +365,7 @@ void CardDAVAddressBookFeeder::process()
     m_blockInfo.responseCode =
             settings.value("blockSipCode", GONNECT_DEFAULT_BLOCK_SIP_CODE).toUInt();
 
-    m_displayName = settings.value("displayName", "").toString();
+    m_displayName = settings.value("displayName", m_group).toString();
     bool ok = true;
     m_priority = settings.value("prio", 0).toUInt(&ok);
     if (!ok) {

--- a/src/contacts/csv/CSVFileAddressBookFeeder.cpp
+++ b/src/contacts/csv/CSVFileAddressBookFeeder.cpp
@@ -25,7 +25,7 @@ void CsvFileAddressBookFeeder::process()
 
     settings.beginGroup(m_group);
     m_filePath = settings.value("path", "").toString();
-    m_displayName = settings.value("displayName", "").toString();
+    m_displayName = settings.value("displayName", m_group).toString();
 
     m_blockInfo.isBlocking = settings.value("block", false).toBool();
     m_blockInfo.responseCode =

--- a/src/contacts/eds/EDSAddressBookFeeder.cpp
+++ b/src/contacts/eds/EDSAddressBookFeeder.cpp
@@ -178,7 +178,7 @@ void EDSAddressBookFeeder::process()
     ReadOnlyConfdSettings settings;
 
     settings.beginGroup(m_group);
-    m_displayName = settings.value("displayName", "").toString();
+    m_displayName = settings.value("displayName", m_group).toString();
 
     m_blockInfo.isBlocking = settings.value("block", false).toBool();
     m_blockInfo.responseCode =

--- a/src/contacts/ldap/LDAPAddressBookFeeder.cpp
+++ b/src/contacts/ldap/LDAPAddressBookFeeder.cpp
@@ -95,7 +95,7 @@ void LDAPAddressBookFeeder::process()
     ReadOnlyConfdSettings settings;
     settings.beginGroup(m_group);
 
-    m_displayName = settings.value("displayName", "").toString();
+    m_displayName = settings.value("displayName", m_group).toString();
     bool ok = true;
     m_priority = settings.value("prio", 0).toUInt(&ok);
     if (!ok) {


### PR DESCRIPTION
- Fixes the issue described in https://github.com/gonicus/gonnect/pull/446
- Fixes an incomplete operator check for `Contact`
- Uses a fallback method for contact source display names: Use settings group ID