### PR TITLE
feat: ical rrule parsing optimization

### DIFF
--- a/src/calendar/caldav/CalDAVEventFeeder.cpp
+++ b/src/calendar/caldav/CalDAVEventFeeder.cpp
@@ -273,9 +273,10 @@ bool CalDAVEventFeeder::processResponse(const QByteArray &data, const QString &s
 
                 icalrecur_iterator *recurrenceIter = icalrecur_iterator_new(rrule, dtstart);
                 if (recurrenceIter) {
-                    // INFO: Since libical v3.0, a start time can be specified for recurrence
-                    // iterators in order to reduce parsing overhead, i.e. old events that are
-                    // irrelevant to us. This only works for RRULE's that do not contain COUNT
+                    // INFO: Since libical v3.0, a start time limit can be specified for recurrence
+                    // iterators in order to reduce parsing overhead, i.e. for old events that are
+                    // irrelevant to us. This only works for RRULE's that do not contain COUNT.
+                    // https://github.com/libical/libical/blob/3.0/src/libical/icalrecur.h#L291
                     if (rrule.count == 0) {
                         QDateTime timeRangeStart = m_config.timeRangeStart.toUTC();
 

--- a/src/calendar/caldav/CalDAVEventFeeder.cpp
+++ b/src/calendar/caldav/CalDAVEventFeeder.cpp
@@ -290,13 +290,15 @@ bool CalDAVEventFeeder::processResponse(const QByteArray &data, const QString &s
                         recurStartCap.is_date = false;
 
                         if (icaltime_is_valid_time(recurStartCap)) {
-                            if (icalrecur_iterator_set_start(recurrenceIter, recurStartCap) == 0) {
-                                onError("Failed to set RRULE iterator starting date");
+                            if (!icalrecur_iterator_set_start(recurrenceIter, recurStartCap)) {
+                                onError(QString("Failed to set RRULE iterator starting date: %1")
+                                                .arg(icalerror_strerror(icalerrno)));
                                 return false;
                             }
                         } else {
                             qCDebug(lcCalDAVEventFeeder)
-                                    << "Invalid RRULE iterator starting date - skipping";
+                                    << "Invalid RRULE iterator starting date - skipping:"
+                                    << icalerror_strerror(icalerrno);
                         }
                     }
 

--- a/src/calendar/caldav/CalDAVEventFeeder.cpp
+++ b/src/calendar/caldav/CalDAVEventFeeder.cpp
@@ -289,7 +289,15 @@ bool CalDAVEventFeeder::processResponse(const QByteArray &data, const QString &s
                         recurStartCap.second = timeRangeStart.time().second();
                         recurStartCap.is_date = false;
 
-                        icalrecur_iterator_set_start(recurrenceIter, recurStartCap);
+                        if (icaltime_is_valid_time(recurStartCap)) {
+                            if (icalrecur_iterator_set_start(recurrenceIter, recurStartCap) == 0) {
+                                onError("Failed to set RRULE iterator starting date");
+                                return false;
+                            }
+                        } else {
+                            qCDebug(lcCalDAVEventFeeder)
+                                    << "Invalid RRULE iterator starting date - skipping";
+                        }
                     }
 
                     qint64 duration = start.secsTo(end);

--- a/src/calendar/caldav/CalDAVEventFeeder.cpp
+++ b/src/calendar/caldav/CalDAVEventFeeder.cpp
@@ -273,22 +273,22 @@ bool CalDAVEventFeeder::processResponse(const QByteArray &data, const QString &s
 
                 icalrecur_iterator *recurrenceIter = icalrecur_iterator_new(rrule, dtstart);
                 if (recurrenceIter) {
-                    // INFO: Since v3.0, a start time can be specified for libical recurrence iterators
-                    // in order to reduce parsing overhead, i.e. events that are irrelevant to us.
-                    // This only works for RRULE's that do not contain COUNT
-                    // TODO: Check if we can also omit some m_config.timeRangeStart checks below
+                    // INFO: Since libical v3.0, a start time can be specified for recurrence
+                    // iterators in order to reduce parsing overhead, i.e. old events that are
+                    // irrelevant to us. This only works for RRULE's that do not contain COUNT
                     if (rrule.count == 0) {
-                        struct icaltimetype ict = icaltime_null_time();
-
                         QDateTime timeRangeStart = m_config.timeRangeStart.toUTC();
-                        ict.year   = timeRangeStart.date().year();
-                        ict.month  = timeRangeStart.date().month();
-                        ict.day    = timeRangeStart.date().day();
-                        ict.hour   = timeRangeStart.time().hour();
-                        ict.minute = timeRangeStart.time().minute();
-                        ict.second = timeRangeStart.time().second();
 
-                        icalrecur_iterator_set_start(recurrenceIter, ict);
+                        struct icaltimetype recurStartCap = icaltime_null_time();
+                        recurStartCap.year = timeRangeStart.date().year();
+                        recurStartCap.month = timeRangeStart.date().month();
+                        recurStartCap.day = timeRangeStart.date().day();
+                        recurStartCap.hour = timeRangeStart.time().hour();
+                        recurStartCap.minute = timeRangeStart.time().minute();
+                        recurStartCap.second = timeRangeStart.time().second();
+                        recurStartCap.is_date = false;
+
+                        icalrecur_iterator_set_start(recurrenceIter, recurStartCap);
                     }
 
                     qint64 duration = start.secsTo(end);

--- a/src/calendar/caldav/CalDAVEventFeeder.cpp
+++ b/src/calendar/caldav/CalDAVEventFeeder.cpp
@@ -273,6 +273,24 @@ bool CalDAVEventFeeder::processResponse(const QByteArray &data, const QString &s
 
                 icalrecur_iterator *recurrenceIter = icalrecur_iterator_new(rrule, dtstart);
                 if (recurrenceIter) {
+                    // INFO: Since v3.0, a start time can be specified for libical recurrence iterators
+                    // in order to reduce parsing overhead, i.e. events that are irrelevant to us.
+                    // This only works for RRULE's that do not contain COUNT
+                    // TODO: Check if we can also omit some m_config.timeRangeStart checks below
+                    if (rrule.count == 0) {
+                        struct icaltimetype ict = icaltime_null_time();
+
+                        QDateTime timeRangeStart = m_config.timeRangeStart.toUTC();
+                        ict.year   = timeRangeStart.date().year();
+                        ict.month  = timeRangeStart.date().month();
+                        ict.day    = timeRangeStart.date().day();
+                        ict.hour   = timeRangeStart.time().hour();
+                        ict.minute = timeRangeStart.time().minute();
+                        ict.second = timeRangeStart.time().second();
+
+                        icalrecur_iterator_set_start(recurrenceIter, ict);
+                    }
+
                     qint64 duration = start.secsTo(end);
 
                     for (icaltimetype next = icalrecur_iterator_next(recurrenceIter);

--- a/src/calendar/caldav/CalDAVEventFeeder.cpp
+++ b/src/calendar/caldav/CalDAVEventFeeder.cpp
@@ -293,6 +293,9 @@ bool CalDAVEventFeeder::processResponse(const QByteArray &data, const QString &s
                             if (!icalrecur_iterator_set_start(recurrenceIter, recurStartCap)) {
                                 onError(QString("Failed to set RRULE iterator starting date: %1")
                                                 .arg(icalerror_strerror(icalerrno)));
+
+                                icalrecur_iterator_free(recurrenceIter);
+
                                 return false;
                             }
                         } else {

--- a/src/calendar/eds/EDSEventFeeder.cpp
+++ b/src/calendar/eds/EDSEventFeeder.cpp
@@ -564,6 +564,9 @@ void EDSEventFeeder::processEvents(QString clientName, QString clientUid, GSList
                                         << "Failed to set RRULE iterator starting date:"
                                         << i_cal_error_strerror(i_cal_errno_return());
 
+                                g_clear_object(&recurStartCap);
+                                i_cal_recur_iterator_free(recurrenceIter);
+
                                 Q_EMIT feederFailed();
                                 return;
                             }

--- a/src/calendar/eds/EDSEventFeeder.cpp
+++ b/src/calendar/eds/EDSEventFeeder.cpp
@@ -555,7 +555,19 @@ void EDSEventFeeder::processEvents(QString clientName, QString clientUid, GSList
                                             timeRangeStart.time().second());
                         i_cal_time_set_is_date(recurStartCap, FALSE);
 
-                        i_cal_recur_iterator_set_start(recurrenceIter, recurStartCap);
+                        if (i_cal_time_is_valid_time(recurStartCap)) {
+                            if (i_cal_recur_iterator_set_start(recurrenceIter, recurStartCap)
+                                == 0) {
+                                qCCritical(lcEDSEventFeeder)
+                                        << "Failed to set RRULE iterator starting date";
+
+                                Q_EMIT feederFailed();
+                                return;
+                            }
+                        } else {
+                            qCDebug(lcEDSEventFeeder)
+                                    << "Invalid RRULE iterator starting date - skipping";
+                        }
                     }
 
                     qint64 duration = start.secsTo(end);

--- a/src/calendar/eds/EDSEventFeeder.cpp
+++ b/src/calendar/eds/EDSEventFeeder.cpp
@@ -538,6 +538,24 @@ void EDSEventFeeder::processEvents(QString clientName, QString clientUid, GSList
 
                 ICalRecurIterator *recurrenceIter = i_cal_recur_iterator_new(rrule, dtstart);
                 if (recurrenceIter) {
+                    // INFO: Since libical-glib v3.0, a start time can be specified for recurrence
+                    // iterators in order to reduce parsing overhead, i.e. old events that are
+                    // irrelevant to us. This only works for RRULE's that do not contain COUNT
+                    if (i_cal_recurrence_get_count(rrule) == 0) {
+                        QDateTime timeRangeStart = m_timeRangeStart.toUTC();
+
+                        ICalTime *recurStartCap = i_cal_time_new();
+                        i_cal_time_set_date(recurStartCap, timeRangeStart.date().year(),
+                                            timeRangeStart.date().month(),
+                                            timeRangeStart.date().day());
+                        i_cal_time_set_time(recurStartCap, timeRangeStart.time().hour(),
+                                            timeRangeStart.time().minute(),
+                                            timeRangeStart.time().second());
+                        i_cal_time_set_is_date(recurStartCap, FALSE);
+
+                        i_cal_recur_iterator_set_start(recurrenceIter, recurStartCap);
+                    }
+
                     qint64 duration = start.secsTo(end);
 
                     for (ICalTime *next = i_cal_recur_iterator_next(recurrenceIter);

--- a/src/calendar/eds/EDSEventFeeder.cpp
+++ b/src/calendar/eds/EDSEventFeeder.cpp
@@ -536,6 +536,7 @@ void EDSEventFeeder::processEvents(QString clientName, QString clientUid, GSList
                 }
                 exdatesById[id] = exdates;
 
+                ICalTime *recurStartCap = NULL;
                 ICalRecurIterator *recurrenceIter = i_cal_recur_iterator_new(rrule, dtstart);
                 if (recurrenceIter) {
                     // INFO: Since libical-glib v3.0, a start time limit can be specified for
@@ -546,16 +547,18 @@ void EDSEventFeeder::processEvents(QString clientName, QString clientUid, GSList
                     if (i_cal_recurrence_get_count(rrule) == 0) {
                         QDateTime timeRangeStart = m_timeRangeStart.toUTC();
 
-                        ICalTime *recurStartCap = i_cal_time_new();
-                        i_cal_time_set_date(recurStartCap, timeRangeStart.date().year(),
-                                            timeRangeStart.date().month(),
-                                            timeRangeStart.date().day());
-                        i_cal_time_set_time(recurStartCap, timeRangeStart.time().hour(),
-                                            timeRangeStart.time().minute(),
-                                            timeRangeStart.time().second());
-                        i_cal_time_set_is_date(recurStartCap, 0);
+                        recurStartCap = i_cal_time_new();
+                        if (recurStartCap) {
+                            i_cal_time_set_date(recurStartCap, timeRangeStart.date().year(),
+                                                timeRangeStart.date().month(),
+                                                timeRangeStart.date().day());
+                            i_cal_time_set_time(recurStartCap, timeRangeStart.time().hour(),
+                                                timeRangeStart.time().minute(),
+                                                timeRangeStart.time().second());
+                            i_cal_time_set_is_date(recurStartCap, 0);
+                        }
 
-                        if (i_cal_time_is_valid_time(recurStartCap)) {
+                        if (recurStartCap && i_cal_time_is_valid_time(recurStartCap)) {
                             if (!i_cal_recur_iterator_set_start(recurrenceIter, recurStartCap)) {
                                 qCCritical(lcEDSEventFeeder)
                                         << "Failed to set RRULE iterator starting date:"
@@ -602,6 +605,9 @@ void EDSEventFeeder::processEvents(QString clientName, QString clientUid, GSList
                         }
                     }
 
+                    if (recurStartCap) {
+                        g_clear_object(&recurStartCap);
+                    }
                     i_cal_recur_iterator_free(recurrenceIter);
                 }
             } else if (isUpdatedRecurrence) { // Updates of a recurrent event instance

--- a/src/calendar/eds/EDSEventFeeder.cpp
+++ b/src/calendar/eds/EDSEventFeeder.cpp
@@ -523,7 +523,7 @@ void EDSEventFeeder::processEvents(QString clientName, QString clientUid, GSList
             QString location = i_cal_component_get_location(component);
             QString description = i_cal_component_get_description(component);
 
-            if (isRecurrent) { // Recurrent origin event, parsed first
+            if (isRecurrent && rrule) { // Recurrent origin event, parsed first
                 // Get EXDATE's
                 ICalTime *exdate = NULL;
                 QList<QDateTime> exdates;
@@ -538,9 +538,11 @@ void EDSEventFeeder::processEvents(QString clientName, QString clientUid, GSList
 
                 ICalRecurIterator *recurrenceIter = i_cal_recur_iterator_new(rrule, dtstart);
                 if (recurrenceIter) {
-                    // INFO: Since libical-glib v3.0, a start time can be specified for recurrence
-                    // iterators in order to reduce parsing overhead, i.e. old events that are
-                    // irrelevant to us. This only works for RRULE's that do not contain COUNT
+                    // INFO: Since libical-glib v3.0, a start time limit can be specified for
+                    // recurrence iterators in order to reduce parsing overhead, i.e. for old
+                    // events that are irrelevant to us. This only works for RRULE's that
+                    // do not contain COUNT.
+                    // https://github.com/libical/libical/blob/3.0/src/libical/icalrecur.h#L291
                     if (i_cal_recurrence_get_count(rrule) == 0) {
                         QDateTime timeRangeStart = m_timeRangeStart.toUTC();
 

--- a/src/calendar/eds/EDSEventFeeder.cpp
+++ b/src/calendar/eds/EDSEventFeeder.cpp
@@ -553,20 +553,21 @@ void EDSEventFeeder::processEvents(QString clientName, QString clientUid, GSList
                         i_cal_time_set_time(recurStartCap, timeRangeStart.time().hour(),
                                             timeRangeStart.time().minute(),
                                             timeRangeStart.time().second());
-                        i_cal_time_set_is_date(recurStartCap, FALSE);
+                        i_cal_time_set_is_date(recurStartCap, 0);
 
                         if (i_cal_time_is_valid_time(recurStartCap)) {
-                            if (i_cal_recur_iterator_set_start(recurrenceIter, recurStartCap)
-                                == 0) {
+                            if (!i_cal_recur_iterator_set_start(recurrenceIter, recurStartCap)) {
                                 qCCritical(lcEDSEventFeeder)
-                                        << "Failed to set RRULE iterator starting date";
+                                        << "Failed to set RRULE iterator starting date:"
+                                        << i_cal_error_strerror(i_cal_errno_return());
 
                                 Q_EMIT feederFailed();
                                 return;
                             }
                         } else {
                             qCDebug(lcEDSEventFeeder)
-                                    << "Invalid RRULE iterator starting date - skipping";
+                                    << "Invalid RRULE iterator starting date - skipping:"
+                                    << i_cal_error_strerror(i_cal_errno_return());
                         }
                     }
 


### PR DESCRIPTION
Since v3.0, `libical` provides methods to set a start time limit for RRULE iterators - thus (at least in my testing with large calendars) providing a ~20% performance boost for event parsing