### PR TITLE
fix: ensure correct `tag` value type in flatpak manifest

### DIFF
--- a/resources/flatpak/de.gonicus.gonnect.yml
+++ b/resources/flatpak/de.gonicus.gonnect.yml
@@ -143,7 +143,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/pjsip/pjproject.git
-        tag: 2.17
+        tag: '2.17'
         commit: 5a457451fa2712ba18e12b01738e8ff3af2b26fd
         x-checker-data:
           type: git


### PR DESCRIPTION
Fixes the following type of warnings,
that local builds and CI runs both emit:

```
** (flatpak-builder:553): WARNING **: 08:03:36.881: 132:14: '2.17' will be parsed as a number by many YAML parsers
```

See the last occurence of this warning in the CI:
https://github.com/gonicus/gonnect/actions/runs/25786376705/job/75740691679