### PR TITLE
feat: add Blinkstick busylight support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ udevadm trigger
 | kuando       | Busylight UC Omega |
 | Luxafor      | Flag               |
 | Logitech     | Litra Beam LX      |
+| Blinkstick   | All models         |
 
 
 # Automatic video light switching

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -723,6 +723,8 @@ qt_add_qml_module(gonnect
         usb/busylight/LitraBeamLX.cpp
         usb/busylight/LitraGlow.h
         usb/busylight/LitraGlow.cpp
+        usb/busylight/BlinkStick.h
+        usb/busylight/BlinkStick.cpp
 )
 
 if(LINUX)

--- a/src/usb/busylight/BlinkStick.cpp
+++ b/src/usb/busylight/BlinkStick.cpp
@@ -1,0 +1,51 @@
+#include "BlinkStick.h"
+
+#include <QLoggingCategory>
+
+Q_LOGGING_CATEGORY(lcBlinkStick, "gonnect.usb.busylight.BlinkStick")
+
+QSet<IBusylightDevice::SupportedCommands> BlinkStick::supportedCommands()
+{
+    static QSet<IBusylightDevice::SupportedCommands> _commands = {
+        IBusylightDevice::SupportedCommands::BusylightOnOff,
+        IBusylightDevice::SupportedCommands::BusylightColor,
+    };
+    return _commands;
+}
+
+void BlinkStick::send(bool on)
+{
+    if (!m_device) {
+        qCCritical(lcBlinkStick) << "Error: trying to send data while the USB device is not open";
+        return;
+    }
+
+    const int ledCount = 8; // BlinkStick Strip Mini has 8 LEDs
+    const quint8 red = on ? static_cast<quint8>(m_color.red()) : 0x00;
+    const quint8 green = on ? static_cast<quint8>(m_color.green()) : 0x00;
+    const quint8 blue = on ? static_cast<quint8>(m_color.blue()) : 0x00;
+
+    qCDebug(lcBlinkStick) << "Sending color to all" << ledCount << "LEDs: R=" << red << "G=" << green << "B=" << blue;
+
+    bool success = true;
+
+    for (int i = 0; i < ledCount; ++i) {
+        unsigned char buf[6];
+
+        buf[0] = 0x05;      // Report ID: indexed color
+        buf[1] = 0x00;      // Channel
+        buf[2] = i;         // LED index
+        buf[3] = red;
+        buf[4] = green;
+        buf[5] = blue;
+
+        if (hid_write(m_device, buf, sizeof(buf)) < 0) {
+            qCWarning(lcBlinkStick) << "failed to write to BlinkStick LED" << i << ":" << hid_error(m_device);
+            success = false;
+        }
+    }
+
+    if (success) {
+        qCDebug(lcBlinkStick) << "Successfully wrote color to all" << ledCount << "BlinkStick LEDs";
+    }
+}

--- a/src/usb/busylight/BlinkStick.cpp
+++ b/src/usb/busylight/BlinkStick.cpp
@@ -25,22 +25,24 @@ void BlinkStick::send(bool on)
     const quint8 green = on ? static_cast<quint8>(m_color.green()) : 0x00;
     const quint8 blue = on ? static_cast<quint8>(m_color.blue()) : 0x00;
 
-    qCDebug(lcBlinkStick) << "Sending color to all" << ledCount << "LEDs: R=" << red << "G=" << green << "B=" << blue;
+    qCDebug(lcBlinkStick) << "Sending color to all" << ledCount << "LEDs: R=" << red
+                          << "G=" << green << "B=" << blue;
 
     bool success = true;
 
     for (int i = 0; i < ledCount; ++i) {
         unsigned char buf[6];
 
-        buf[0] = 0x05;      // Report ID: indexed color
-        buf[1] = 0x00;      // Channel
-        buf[2] = i;         // LED index
+        buf[0] = 0x05; // Report ID: indexed color
+        buf[1] = 0x00; // Channel
+        buf[2] = i; // LED index
         buf[3] = red;
         buf[4] = green;
         buf[5] = blue;
 
         if (hid_write(m_device, buf, sizeof(buf)) < 0) {
-            qCWarning(lcBlinkStick) << "failed to write to BlinkStick LED" << i << ":" << hid_error(m_device);
+            qCWarning(lcBlinkStick)
+                    << "failed to write to BlinkStick LED" << i << ":" << hid_error(m_device);
             success = false;
         }
     }

--- a/src/usb/busylight/BlinkStick.h
+++ b/src/usb/busylight/BlinkStick.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "IBusylightDevice.h"
+#include "hidapi.h"
+
+class BlinkStick : public IBusylightDevice
+{
+    Q_OBJECT
+
+public:
+    BlinkStick(const hid_device_info &deviceInfo, QObject *parent = nullptr)
+        : IBusylightDevice{ deviceInfo, parent } { };
+
+    QSet<SupportedCommands> supportedCommands() override;
+
+protected:
+    void send(bool on) override;
+};

--- a/src/usb/busylight/BusylightDeviceManager.cpp
+++ b/src/usb/busylight/BusylightDeviceManager.cpp
@@ -4,6 +4,7 @@
 #include "LitraGlow.h"
 #include "LuxaforFlag.h"
 #include "KuandoOmega.h"
+#include "BlinkStick.h"
 #include "GlobalCallState.h"
 #include "GlobalMuteState.h"
 
@@ -36,6 +37,9 @@ bool BusylightDeviceManager::createBusylightDevice(const hid_device_info &device
 
     } else if (vendor == 0x046D && product == 0xC903) {
         device = new LitraBeamLX(deviceInfo, this);
+
+    } else if (vendor == 0x20A0 && product == 0x41E5) {
+        device = new BlinkStick(deviceInfo, this);
     }
 
     if (device) {


### PR DESCRIPTION
Add support for [BlinkStick](https://www.blinkstick.com/) USB LED devices as busylight option.

- Vendor ID: 0x20A0, Product ID: 0x41E5
- Uses HID feature report for RGB Colors
- Supports BusylightOnOff and BusylightColor commands
- No external library dependencies (uses only HID Commands already used in Gonnect)
- Lights up up to 8 LEDs on BlinkStick models (most have below 8)

Signed-off-by: Fabian Thoma <f@bianthoma.me>