### PR TITLE
fix: clear out URI encoded number input

### DIFF
--- a/.github/actions/prepare-linux/action.yml
+++ b/.github/actions/prepare-linux/action.yml
@@ -52,7 +52,7 @@ runs:
       if: inputs.conan == 'true'
       uses: conan-io/setup-conan@2f4bd34e8e0af00e1a77a66e1d284e06d71d703f # v1
       with:
-        version: 2.25.1
+        version: 2.28.1
         cache_packages: true
 
     - name: Install Conan dependencies

--- a/.github/actions/prepare-macos/action.yml
+++ b/.github/actions/prepare-macos/action.yml
@@ -37,7 +37,7 @@ runs:
     - name: Install Conan
       uses: conan-io/setup-conan@2f4bd34e8e0af00e1a77a66e1d284e06d71d703f # v1
       with:
-        version: 2.25.1
+        version: 2.28.1
         cache_packages: true
 
     - name: Install Conan dependencies

--- a/.github/actions/prepare-windows/action.yml
+++ b/.github/actions/prepare-windows/action.yml
@@ -40,7 +40,7 @@ runs:
     - name: Install Conan
       uses: conan-io/setup-conan@2f4bd34e8e0af00e1a77a66e1d284e06d71d703f # v1
       with:
-        version: 2.25.1
+        version: 2.28.1
         cache_packages: true
 
     - name: Install Conan dependencies

--- a/src/contacts/PhoneNumberUtil.cpp
+++ b/src/contacts/PhoneNumberUtil.cpp
@@ -45,7 +45,7 @@ bool ContactInfo::operator!=(const ContactInfo &other)
 
 QString PhoneNumberUtil::cleanPhoneNumber(const QString &number)
 {
-    QString result(number);
+    QString result(QUrl::fromPercentEncoding(number.toLocal8Bit()));
 
     static const QRegularExpression stripRegEx("[^0-9#+*]");
     result.replace(stripRegEx, "");

--- a/tests/Contacts.test.cpp
+++ b/tests/Contacts.test.cpp
@@ -13,6 +13,9 @@ void ContactsTest::testCleanPhoneNumber()
     // Strip whitespace and -
     QCOMPARE(PhoneNumberUtil::cleanPhoneNumber("  +49 2931 9160   "), QString("+4929319160"));
     QCOMPARE(PhoneNumberUtil::cleanPhoneNumber("  +49-2931-9160   "), QString("+4929319160"));
+    // Handle URL encoded numbers
+    QCOMPARE(PhoneNumberUtil::cleanPhoneNumber("callto:+49%202932%209160"), QString("+4929329160"));
+    QCOMPARE(PhoneNumberUtil::cleanPhoneNumber("%2B49%202932%209160"), QString("+4929329160"));
 }
 
 void ContactsTest::testLevenshteinDistance()


### PR DESCRIPTION
In some cases websites contain broken callto/tel refs that contain URI encoded parts (i.e. %20 for space). Convert these before applying the number cleaner.