### PR TITLE
fix: disable DTMF Flash

### DIFF
--- a/resources/conan/recipes/pjproject/all/conanfile.py
+++ b/resources/conan/recipes/pjproject/all/conanfile.py
@@ -158,6 +158,7 @@ class PjSIPConan(ConanFile):
         with open(os.path.join(self.build_folder, 'pjlib/include/pj/config_site.h'), 'a') as file:
             file.write('\n\n#define PJ_HAS_IPV6 1\n')
             file.write('\n\n#define PJMEDIA_HAS_RTCP_XR 1\n')
+            file.write('\n\n#define PJMEDIA_HAS_DTMF_FLASH 0\n')
             file.write('\n\n#define PJSIP_MAX_PKT_LEN 8192\n')
 
             if self.settings.os == "Macos":

--- a/resources/flatpak/patches/pjproject-site-config.patch
+++ b/resources/flatpak/patches/pjproject-site-config.patch
@@ -1,8 +1,9 @@
 diff -Naur a/pjlib/include/pj/config_site.h b/pjlib/include/pj/config_site.h
 --- a/pjlib/include/pj/config_site.h	1970-01-01 01:00:00.000000000 +0100
-+++ b/pjlib/include/pj/config_site.h	2026-02-21 11:01:42.405437418 +0100
-@@ -0,0 +1,4 @@
++++ b/pjlib/include/pj/config_site.h	2026-05-27 18:08:31.468851416 +0200
+@@ -0,0 +1,5 @@
 +#define PJ_HAS_IPV6 1
 +#define PJSIP_MAX_PKT_LEN 8192
 +#define PJMEDIA_HAS_RTCP_XR 1
 +#define PJMEDIA_HAS_RTT 0
++#define PJMEDIA_HAS_DTMF_FLASH 0


### PR DESCRIPTION
CUCM sends

  a=rtpmap:101 telephone-event/8000
  a=fmtp:101 0-15

and GOnnect signals that it can do flash

  a=fmtp:101 0-16

CUCM doesn't agree here and simply hangs up. As we've no flash, just disable this feature in pjsip.