### PR TITLE
fix: dtmf post dial

### DIFF
--- a/src/sip/DtmfGenerator.cpp
+++ b/src/sip/DtmfGenerator.cpp
@@ -15,10 +15,8 @@ DtmfGenerator::DtmfGenerator(QObject *parent)
 void DtmfGenerator::playDtmf(const QChar &key)
 {
     const auto lower = key.toLower();
-    const static QSet<QChar> allowedChars = { '0', '1', '2', '3', '4', '5', '6', '7', '8',
-                                              '9', '0', '#', '*', 'a', 'b', 'c', 'd' };
 
-    if (!allowedChars.contains(lower)) {
+    if (!isValid(lower)) {
         qCWarning(lcDtmfGenerator) << "Ignoring unknown DTMF char" << lower;
         return;
     }
@@ -29,4 +27,11 @@ void DtmfGenerator::playDtmf(const QChar &key)
     digitDesc.off_msec = 0;
 
     m_toneGen.playDigits({ digitDesc });
+}
+
+bool DtmfGenerator::isValid(const QChar &key)
+{
+    const static QSet<QChar> allowedChars = { '0', '1', '2', '3', '4', '5', '6', '7',
+                                              '8', '9', '#', '*', 'a', 'b', 'c', 'd' };
+    return allowedChars.contains(key.toLower());
 }

--- a/src/sip/DtmfGenerator.h
+++ b/src/sip/DtmfGenerator.h
@@ -14,6 +14,8 @@ public:
     /// Plays the given key (single digit, *, #, A-D)
     void playDtmf(const QChar &key);
 
+    static bool isValid(const QChar &key);
+
 private:
     pj::ToneGenerator m_toneGen;
     pj::AudioMedia &m_mediaSink;

--- a/src/sip/SIPAccount.cpp
+++ b/src/sip/SIPAccount.cpp
@@ -490,6 +490,13 @@ QString SIPAccount::call(const QString &number, const QString &contactId,
 
     generatePreferredIdentityHeader(number, preferredIdentity, prm);
 
+    if (!PhoneNumberUtil::isSipUri(number)) {
+        const QString postDialDtmf = number.section(',', 1, -1, QString::SectionIncludeLeadingSep);
+        if (!postDialDtmf.isEmpty()) {
+            call->setPostDialDtmf(postDialDtmf);
+        }
+    }
+
     try {
         call->call(sipUrl, prm);
         m_calls.push_back(call);

--- a/src/sip/SIPCall.cpp
+++ b/src/sip/SIPCall.cpp
@@ -129,9 +129,6 @@ SIPCall::~SIPCall()
 
 void SIPCall::call(const QString &dst_uri, const pj::CallOpParam &prm)
 {
-    // Extract "," DTMF string and store them for later playback
-    m_postTask = dst_uri.section(',', 1, -1, QString::SectionIncludeLeadingSep);
-
     if (m_account && m_account->isRTTEnabled()) {
         makeCall(dst_uri.toStdString(), prm);
     } else {

--- a/src/sip/SIPCall.h
+++ b/src/sip/SIPCall.h
@@ -48,6 +48,7 @@ public:
     bool isIncoming() const { return m_incoming; }
 
     void call(const QString &dst_uri, const pj::CallOpParam &prm);
+    void setPostDialDtmf(const QString &dtmf) { m_postTask = dtmf; }
 
     void addMetadata(const QString &data);
     bool hasMetadata() const { return m_hasMetadata; }

--- a/src/sip/SIPCallManager.cpp
+++ b/src/sip/SIPCallManager.cpp
@@ -933,8 +933,20 @@ void SIPCallManager::dispatchDtmfBuffer()
                             m_dtmfGen = new DtmfGenerator(this);
                         }
 
-                        m_dtmfGen->playDtmf(val.front());
-                        call->dialDtmf(val.first(1).toStdString());
+                        const QChar digit = val.front();
+                        if (DtmfGenerator::isValid(digit)) {
+                            m_dtmfGen->playDtmf(digit);
+                            try {
+                                call->dialDtmf(val.first(1).toStdString());
+                            } catch (const pj::Error &err) {
+                                qCWarning(lcSIPCallManager)
+                                        << "error sending DTMF char" << digit << ":"
+                                        << QString::fromStdString(err.info());
+                            }
+
+                        } else {
+                            qCWarning(lcSIPCallManager) << "skipping invalid DTMF char" << digit;
+                        }
 
                         m_dtmfTimer.setInterval(PJSUA_CALL_SEND_DTMF_DURATION_DEFAULT + 10);
                     }


### PR DESCRIPTION
DTMF post dial was also triggered with SIP URIs. These can contain a name like in

```
"Foo, Bar" <sip:.....>
```

The "," was used for the post dial detection and it started to send DTMF " ", "B", "a", etc. This lead into an assertion, because the call->dialDtmf was not guarded by try/catch.