### PR TITLE
fix: encrypted messages without content

### DIFF
--- a/src/chat/ChatMessage.cpp
+++ b/src/chat/ChatMessage.cpp
@@ -17,10 +17,12 @@ ChatMessage::ChatMessage(const QString &eventId, const QString &fromId, const QS
 {
     Q_CHECK_PTR(chatRoom);
 
-    content->setParent(this);
+    if (content) {
+        content->setParent(this);
 
-    if (auto *textContent = qobject_cast<ChatMessageContentText *>(content)) {
-        textContent->processText();
+        if (auto *textContent = qobject_cast<ChatMessageContentText *>(content)) {
+            textContent->processText();
+        }
     }
 }
 

--- a/src/chat/IChatRoom.h
+++ b/src/chat/IChatRoom.h
@@ -186,6 +186,7 @@ Q_SIGNALS:
     void isCompletelyLoadedChanged();
     void latestMessageDateTimeChanged();
     void ownUserJoinStateChanged();
+    void otherUserChanged();
 
     /// Send when a chat message has been added. index is the one in the list returned by
     /// chatMessages(). Ownership remains in this room object.

--- a/src/chat/IpcChatRoom.h
+++ b/src/chat/IpcChatRoom.h
@@ -70,9 +70,6 @@ public:
 
     void setTypingUsers(const QList<ChatUser *> &users);
 
-Q_SIGNALS:
-    void otherUserChanged();
-
 private Q_SLOTS:
     void updateIsDirectChat();
     void updateOtherUser();

--- a/src/ui/CallsModel.cpp
+++ b/src/ui/CallsModel.cpp
@@ -227,6 +227,7 @@ QHash<int, QByteArray> CallsModel::roleNames() const
         { static_cast<int>(Roles::RemoteUri), "remoteUri" },
         { static_cast<int>(Roles::PhoneNumber), "phoneNumber" },
         { static_cast<int>(Roles::IsIncoming), "isIncoming" },
+        { static_cast<int>(Roles::Contact), "contact" },
         { static_cast<int>(Roles::ContactName), "contactName" },
         { static_cast<int>(Roles::City), "city" },
         { static_cast<int>(Roles::Country), "country" },
@@ -414,6 +415,9 @@ QVariant CallsModel::data(const QModelIndex &index, int role) const
     case static_cast<int>(Roles::PhoneNumber):
         return callInfo->contactInfo.isAnonymous ? tr("unknown number")
                                                  : callInfo->contactInfo.phoneNumber;
+
+    case static_cast<int>(Roles::Contact):
+        return QVariant::fromValue(callInfo->contactInfo.contact);
 
     case static_cast<int>(Roles::ContactName):
         return !callInfo->contactInfo.displayName.isEmpty() ? callInfo->contactInfo.displayName

--- a/src/ui/CallsModel.h
+++ b/src/ui/CallsModel.h
@@ -58,6 +58,7 @@ public:
         AccountId,
         RemoteUri,
         PhoneNumber,
+        Contact,
         ContactName,
         IsIncoming,
         City,

--- a/src/ui/components/CallItem.qml
+++ b/src/ui/components/CallItem.qml
@@ -17,6 +17,7 @@ Rectangle {
     required property int callId
     required property string accountId
     required property string phoneNumber
+    required property Contact contact
     required property string contactName
     required property string city
     required property string country

--- a/src/ui/components/chat/ChatMessageListItemContent.qml
+++ b/src/ui/components/chat/ChatMessageListItemContent.qml
@@ -8,7 +8,9 @@ import base
 Item {
     id: control
     implicitWidth: {
-        if (control.isStateUpdate) {
+        if (!control.content) {
+            return 0
+        } else if (control.isStateUpdate) {
             return stateLabel.implicitWidth
         } else if (control.content instanceof ChatMessageContentText && control.content.isSimpleText) {
             return messageLabel.implicitWidth
@@ -20,7 +22,9 @@ Item {
         return 36
     }
     implicitHeight: {
-        if (control.isStateUpdate) {
+        if (!control.content) {
+            return 0
+        } else if (control.isStateUpdate) {
             return stateLabel.implicitHeight
         } else if (control.content instanceof ChatMessageContentText && control.content.isSimpleText) {
             return messageLabel.implicitHeight


### PR DESCRIPTION
Fixes a segfault due to a nullptr access on encrypted messages, which have no inner content object yet.