### PR TITLE
fix: hold on makel

### DIFF
--- a/src/GlobalCallState.cpp
+++ b/src/GlobalCallState.cpp
@@ -86,12 +86,23 @@ bool GlobalCallState::unregisterCallStateObject(ICallState *callStateObject)
 void GlobalCallState::updateGlobalCallState()
 {
     ICallState::States globalState = ICallState::State::Idle;
+    bool hasNonHoldCall = false;
+
     for (const auto obj : std::as_const(m_globalCallStateObjects)) {
         auto state = obj->callState();
         globalState |= state;
+
+        if ((state & ICallState::State::CallActive) && !(state & ICallState::State::OnHold)) {
+            hasNonHoldCall = true;
+        }
+    }
+
+    if (hasNonHoldCall) {
+        globalState.setFlag(ICallState::State::OnHold, false);
     }
 
     setGlobalCallState(globalState);
+
     updateRemoteContactInfo();
     Q_EMIT activeCallsCountChanged();
     Q_EMIT nonIdleCallsCountChanged();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,11 +43,10 @@ static int setup_unix_signal_handlers()
 
 int main(int argc, char *argv[])
 {
-    qSetMessagePattern(
-            "\033[32m%{time h:mm:ss.zzz}%{if-category}\033[32m %{category}:%{endif} "
-            "%{if-debug}\033[34m%{function}%{endif}%{if-warning}\033[31m%{endif}"
-            "%{if-critical}\033[31m%{endif}"
-            "%{if-fatal}\033[31m%{backtrace depth=3}%{endif}\033[0m %{message}");
+    qSetMessagePattern("\033[32m%{time h:mm:ss.zzz}%{if-category}\033[32m %{category}:%{endif} "
+                       "%{if-debug}\033[34m%{function}%{endif}%{if-warning}\033[31m%{endif}"
+                       "%{if-critical}\033[31m%{endif}"
+                       "%{if-fatal}\033[31m%{backtrace depth=3}%{endif}\033[0m %{message}");
     setup_unix_signal_handlers();
 
     QtWebEngineQuick::initialize();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,9 +45,9 @@ int main(int argc, char *argv[])
 {
     qSetMessagePattern(
             "\033[32m%{time h:mm:ss.zzz}%{if-category}\033[32m %{category}:%{endif} "
-            "%{if-debug}\033[34m%{function}%{endif}%{if-warning}\033[31m%{backtrace "
-            "depth=3}%{endif}%{if-critical}\033[31m%{backtrace "
-            "depth=3}%{endif}%{if-fatal}\033[31m%{backtrace depth=3}%{endif}\033[0m %{message}");
+            "%{if-debug}\033[34m%{function}%{endif}%{if-warning}\033[31m%{endif}"
+            "%{if-critical}\033[31m%{endif}"
+            "%{if-fatal}\033[31m%{backtrace depth=3}%{endif}\033[0m %{message}");
     setup_unix_signal_handlers();
 
     QtWebEngineQuick::initialize();

--- a/src/sip/SIPCallManager.cpp
+++ b/src/sip/SIPCallManager.cpp
@@ -75,31 +75,25 @@ SIPCallManager::SIPCallManager(QObject *parent) : QObject(parent)
             return;
         }
 
-        // Were're busy with one call and there's one incoming -> end call active call and pick
-        // incoming one
+        // Were're busy with two calls - distinguish between "active + incoming"
+        // and "active + hold".
         if (!dev->getHookSwitch() && callsCount == 2) {
             SIPCall *_activeCall = nullptr;
             SIPCall *_incomingCall = nullptr;
 
             for (auto call : std::as_const(m_calls)) {
-                if (_activeCall && _incomingCall) {
-                    break;
-                }
-
-                if (call->isEstablished() && call->isActive()) {
+                if (call->isEstablished() && call->isActive() && !call->isHolding()) {
                     _activeCall = call;
-                    continue;
-                }
-
-                if (!call->isEstablished() && call->isIncoming()) {
+                } else if (!call->isEstablished() && call->isIncoming()) {
                     _incomingCall = call;
-                    continue;
                 }
             }
 
             if (_activeCall && _incomingCall) {
                 endCall(_activeCall);
                 _incomingCall->accept();
+            } else if (_activeCall) {
+                endCall(_activeCall);
             }
 
             return;
@@ -790,7 +784,7 @@ void SIPCallManager::removeCall(SIPCall *call)
                     pj::CallInfo info = remainingCall->getInfo();
 
                     if (info.state == PJSIP_INV_STATE_CONFIRMED) {
-                        remainingCall->unhold();
+                        remainingCall->toggleHold();
                     }
                 } catch (pj::Error &) {
                     // This means the call is terminated or currently in termination. That is fine,


### PR DESCRIPTION
Fix the headset "makeln" where we run into the case that the second call is active in the UI, but the headset thinks it's still "on hold" and therefore muted. Also address a stuck "auto resume" on "hangup".