### PR TITLE
fix: random crash on tear down

### DIFF
--- a/src/AuthManager.h
+++ b/src/AuthManager.h
@@ -112,8 +112,11 @@ class AuthManagerWrapper
     QML_SINGLETON
 
 public:
-    static AuthManager *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&AuthManager::instance(), QQmlEngine::CppOwnership);
-        return &AuthManager::instance(); }
+    static AuthManager *create(QQmlEngine *, QJSEngine *)
+    {
+        QQmlEngine::setObjectOwnership(&AuthManager::instance(), QQmlEngine::CppOwnership);
+        return &AuthManager::instance();
+    }
 
 private:
     AuthManagerWrapper() = default;

--- a/src/AuthManager.h
+++ b/src/AuthManager.h
@@ -112,7 +112,8 @@ class AuthManagerWrapper
     QML_SINGLETON
 
 public:
-    static AuthManager *create(QQmlEngine *, QJSEngine *) { return &AuthManager::instance(); }
+    static AuthManager *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&AuthManager::instance(), QQmlEngine::CppOwnership);
+        return &AuthManager::instance(); }
 
 private:
     AuthManagerWrapper() = default;

--- a/src/ErrorBus.h
+++ b/src/ErrorBus.h
@@ -36,8 +36,11 @@ class ErrorBusWrapper
     QML_SINGLETON
 
 public:
-    static ErrorBus *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&ErrorBus::instance(), QQmlEngine::CppOwnership);
-        return &ErrorBus::instance(); }
+    static ErrorBus *create(QQmlEngine *, QJSEngine *)
+    {
+        QQmlEngine::setObjectOwnership(&ErrorBus::instance(), QQmlEngine::CppOwnership);
+        return &ErrorBus::instance();
+    }
 
 private:
     ErrorBusWrapper() = default;

--- a/src/ErrorBus.h
+++ b/src/ErrorBus.h
@@ -36,7 +36,8 @@ class ErrorBusWrapper
     QML_SINGLETON
 
 public:
-    static ErrorBus *create(QQmlEngine *, QJSEngine *) { return &ErrorBus::instance(); }
+    static ErrorBus *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&ErrorBus::instance(), QQmlEngine::CppOwnership);
+        return &ErrorBus::instance(); }
 
 private:
     ErrorBusWrapper() = default;

--- a/src/GlobalCallState.h
+++ b/src/GlobalCallState.h
@@ -91,6 +91,7 @@ class GlobalCallStateWrapper
 public:
     static GlobalCallState *create(QQmlEngine *, QJSEngine *)
     {
+        QQmlEngine::setObjectOwnership(&GlobalCallState::instance(), QQmlEngine::CppOwnership);
         return &GlobalCallState::instance();
     }
 

--- a/src/GlobalInfo.h
+++ b/src/GlobalInfo.h
@@ -63,7 +63,8 @@ class GlobalInfoWrapper
     QML_SINGLETON
 
 public:
-    static GlobalInfo *create(QQmlEngine *, QJSEngine *) { return &GlobalInfo::instance(); }
+    static GlobalInfo *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&GlobalInfo::instance(), QQmlEngine::CppOwnership);
+        return &GlobalInfo::instance(); }
 
 private:
     GlobalInfoWrapper() = default;

--- a/src/GlobalInfo.h
+++ b/src/GlobalInfo.h
@@ -63,8 +63,11 @@ class GlobalInfoWrapper
     QML_SINGLETON
 
 public:
-    static GlobalInfo *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&GlobalInfo::instance(), QQmlEngine::CppOwnership);
-        return &GlobalInfo::instance(); }
+    static GlobalInfo *create(QQmlEngine *, QJSEngine *)
+    {
+        QQmlEngine::setObjectOwnership(&GlobalInfo::instance(), QQmlEngine::CppOwnership);
+        return &GlobalInfo::instance();
+    }
 
 private:
     GlobalInfoWrapper() = default;

--- a/src/GlobalMuteState.h
+++ b/src/GlobalMuteState.h
@@ -47,6 +47,7 @@ class GlobalMuteStateWrapper
 public:
     static GlobalMuteState *create(QQmlEngine *, QJSEngine *)
     {
+        QQmlEngine::setObjectOwnership(&GlobalMuteState::instance(), QQmlEngine::CppOwnership);
         return &GlobalMuteState::instance();
     }
 

--- a/src/SelectionState.h
+++ b/src/SelectionState.h
@@ -73,7 +73,8 @@ class SelectionStateWrapper
     QML_SINGLETON
 
 public:
-    static SelectionState *create(QQmlEngine *, QJSEngine *) { return &SelectionState::instance(); }
+    static SelectionState *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&SelectionState::instance(), QQmlEngine::CppOwnership);
+        return &SelectionState::instance(); }
 
 private:
     SelectionStateWrapper() = default;

--- a/src/SelectionState.h
+++ b/src/SelectionState.h
@@ -73,8 +73,11 @@ class SelectionStateWrapper
     QML_SINGLETON
 
 public:
-    static SelectionState *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&SelectionState::instance(), QQmlEngine::CppOwnership);
-        return &SelectionState::instance(); }
+    static SelectionState *create(QQmlEngine *, QJSEngine *)
+    {
+        QQmlEngine::setObjectOwnership(&SelectionState::instance(), QQmlEngine::CppOwnership);
+        return &SelectionState::instance();
+    }
 
 private:
     SelectionStateWrapper() = default;

--- a/src/StateManager.h
+++ b/src/StateManager.h
@@ -87,8 +87,11 @@ class StateManagerWrapper
     QML_SINGLETON
 
 public:
-    static StateManager *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&StateManager::instance(), QQmlEngine::CppOwnership);
-        return &StateManager::instance(); }
+    static StateManager *create(QQmlEngine *, QJSEngine *)
+    {
+        QQmlEngine::setObjectOwnership(&StateManager::instance(), QQmlEngine::CppOwnership);
+        return &StateManager::instance();
+    }
 
 private:
     StateManagerWrapper() = default;

--- a/src/StateManager.h
+++ b/src/StateManager.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QQmlEngine>
+
 #include <QObject>
 #include <QtQml/qqml.h>
 #include <QtQml/qqmlregistration.h>
@@ -85,7 +87,8 @@ class StateManagerWrapper
     QML_SINGLETON
 
 public:
-    static StateManager *create(QQmlEngine *, QJSEngine *) { return &StateManager::instance(); }
+    static StateManager *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&StateManager::instance(), QQmlEngine::CppOwnership);
+        return &StateManager::instance(); }
 
 private:
     StateManagerWrapper() = default;

--- a/src/UISettings.h
+++ b/src/UISettings.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QQmlEngine>
+
 #include <QObject>
 #include <QtQml/qqml.h>
 #include <QtQml/qqmlregistration.h>
@@ -49,7 +51,8 @@ class UISettingsWrapper
     QML_SINGLETON
 
 public:
-    static UISettings *create(QQmlEngine *, QJSEngine *) { return &UISettings::instance(); }
+    static UISettings *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&UISettings::instance(), QQmlEngine::CppOwnership);
+        return &UISettings::instance(); }
 
 private:
     UISettingsWrapper() = default;

--- a/src/UISettings.h
+++ b/src/UISettings.h
@@ -51,8 +51,11 @@ class UISettingsWrapper
     QML_SINGLETON
 
 public:
-    static UISettings *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&UISettings::instance(), QQmlEngine::CppOwnership);
-        return &UISettings::instance(); }
+    static UISettings *create(QQmlEngine *, QJSEngine *)
+    {
+        QQmlEngine::setObjectOwnership(&UISettings::instance(), QQmlEngine::CppOwnership);
+        return &UISettings::instance();
+    }
 
 private:
     UISettingsWrapper() = default;

--- a/src/chat/ChatConnectorManager.h
+++ b/src/chat/ChatConnectorManager.h
@@ -80,6 +80,7 @@ class ChatConnectorManagerWrapper
 public:
     static ChatConnectorManager *create(QQmlEngine *, QJSEngine *)
     {
+        QQmlEngine::setObjectOwnership(&ChatConnectorManager::instance(), QQmlEngine::CppOwnership);
         return &ChatConnectorManager::instance();
     }
 

--- a/src/helper/TextFormatHelper.h
+++ b/src/helper/TextFormatHelper.h
@@ -33,6 +33,7 @@ class TextFormatHelperWrapper
 public:
     static TextFormatHelper *create(QQmlEngine *, QJSEngine *)
     {
+        QQmlEngine::setObjectOwnership(&TextFormatHelper::instance(), QQmlEngine::CppOwnership);
         return &TextFormatHelper::instance();
     }
 

--- a/src/media/AudioManager.h
+++ b/src/media/AudioManager.h
@@ -156,8 +156,11 @@ class AudioManagerWrapper
     QML_SINGLETON
 
 public:
-    static AudioManager *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&AudioManager::instance(), QQmlEngine::CppOwnership);
-        return &AudioManager::instance(); }
+    static AudioManager *create(QQmlEngine *, QJSEngine *)
+    {
+        QQmlEngine::setObjectOwnership(&AudioManager::instance(), QQmlEngine::CppOwnership);
+        return &AudioManager::instance();
+    }
 
 private:
     AudioManagerWrapper() = default;

--- a/src/media/AudioManager.h
+++ b/src/media/AudioManager.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QQmlEngine>
+
 #include <QObject>
 
 #include <QMediaDevices>
@@ -154,7 +156,8 @@ class AudioManagerWrapper
     QML_SINGLETON
 
 public:
-    static AudioManager *create(QQmlEngine *, QJSEngine *) { return &AudioManager::instance(); }
+    static AudioManager *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&AudioManager::instance(), QQmlEngine::CppOwnership);
+        return &AudioManager::instance(); }
 
 private:
     AudioManagerWrapper() = default;

--- a/src/media/VideoManager.h
+++ b/src/media/VideoManager.h
@@ -60,7 +60,8 @@ class VideoManagerWrapper
     QML_SINGLETON
 
 public:
-    static VideoManager *create(QQmlEngine *, QJSEngine *) { return &VideoManager::instance(); }
+    static VideoManager *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&VideoManager::instance(), QQmlEngine::CppOwnership);
+        return &VideoManager::instance(); }
 
 private:
     VideoManagerWrapper() = default;

--- a/src/media/VideoManager.h
+++ b/src/media/VideoManager.h
@@ -60,8 +60,11 @@ class VideoManagerWrapper
     QML_SINGLETON
 
 public:
-    static VideoManager *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&VideoManager::instance(), QQmlEngine::CppOwnership);
-        return &VideoManager::instance(); }
+    static VideoManager *create(QQmlEngine *, QJSEngine *)
+    {
+        QQmlEngine::setObjectOwnership(&VideoManager::instance(), QQmlEngine::CppOwnership);
+        return &VideoManager::instance();
+    }
 
 private:
     VideoManagerWrapper() = default;

--- a/src/platform/SearchProvider.h
+++ b/src/platform/SearchProvider.h
@@ -28,8 +28,11 @@ class SearchProviderWrapper
     QML_SINGLETON
 
 public:
-    static SearchProvider *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&SearchProvider::instance(), QQmlEngine::CppOwnership);
-        return &SearchProvider::instance(); }
+    static SearchProvider *create(QQmlEngine *, QJSEngine *)
+    {
+        QQmlEngine::setObjectOwnership(&SearchProvider::instance(), QQmlEngine::CppOwnership);
+        return &SearchProvider::instance();
+    }
 
 private:
     SearchProviderWrapper() = default;

--- a/src/platform/SearchProvider.h
+++ b/src/platform/SearchProvider.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QQmlEngine>
+
 #include <QObject>
 #include <QHash>
 #include <QtQml/qqml.h>
@@ -26,7 +28,8 @@ class SearchProviderWrapper
     QML_SINGLETON
 
 public:
-    static SearchProvider *create(QQmlEngine *, QJSEngine *) { return &SearchProvider::instance(); }
+    static SearchProvider *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&SearchProvider::instance(), QQmlEngine::CppOwnership);
+        return &SearchProvider::instance(); }
 
 private:
     SearchProviderWrapper() = default;

--- a/src/presence/GlobalStateAggregator.h
+++ b/src/presence/GlobalStateAggregator.h
@@ -47,6 +47,7 @@ class GlobalStateAggregatorWrapper
 public:
     static GlobalStateAggregator *create(QQmlEngine *, QJSEngine *)
     {
+        QQmlEngine::setObjectOwnership(&GlobalStateAggregator::instance(), QQmlEngine::CppOwnership);
         return &GlobalStateAggregator::instance();
     }
 

--- a/src/presence/GlobalStateAggregator.h
+++ b/src/presence/GlobalStateAggregator.h
@@ -47,7 +47,8 @@ class GlobalStateAggregatorWrapper
 public:
     static GlobalStateAggregator *create(QQmlEngine *, QJSEngine *)
     {
-        QQmlEngine::setObjectOwnership(&GlobalStateAggregator::instance(), QQmlEngine::CppOwnership);
+        QQmlEngine::setObjectOwnership(&GlobalStateAggregator::instance(),
+                                       QQmlEngine::CppOwnership);
         return &GlobalStateAggregator::instance();
     }
 

--- a/src/rtt/RTTProvider.h
+++ b/src/rtt/RTTProvider.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QQmlEngine>
+
 #include <QObject>
 #include <QtQml/qqml.h>
 #include <QtQml/qqmlregistration.h>
@@ -81,7 +83,8 @@ class RTTProviderWrapper
     QML_SINGLETON
 
 public:
-    static RTTProvider *create(QQmlEngine *, QJSEngine *) { return &RTTProvider::instance(); }
+    static RTTProvider *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&RTTProvider::instance(), QQmlEngine::CppOwnership);
+        return &RTTProvider::instance(); }
 
 private:
     RTTProviderWrapper() = default;

--- a/src/rtt/RTTProvider.h
+++ b/src/rtt/RTTProvider.h
@@ -83,8 +83,11 @@ class RTTProviderWrapper
     QML_SINGLETON
 
 public:
-    static RTTProvider *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&RTTProvider::instance(), QQmlEngine::CppOwnership);
-        return &RTTProvider::instance(); }
+    static RTTProvider *create(QQmlEngine *, QJSEngine *)
+    {
+        QQmlEngine::setObjectOwnership(&RTTProvider::instance(), QQmlEngine::CppOwnership);
+        return &RTTProvider::instance();
+    }
 
 private:
     RTTProviderWrapper() = default;

--- a/src/sip/PreferredIdentityValidator.h
+++ b/src/sip/PreferredIdentityValidator.h
@@ -39,7 +39,8 @@ class PreferredIdentityValidatorWrapper
 public:
     static PreferredIdentityValidator *create(QQmlEngine *, QJSEngine *)
     {
-        QQmlEngine::setObjectOwnership(&PreferredIdentityValidator::instance(), QQmlEngine::CppOwnership);
+        QQmlEngine::setObjectOwnership(&PreferredIdentityValidator::instance(),
+                                       QQmlEngine::CppOwnership);
         return &PreferredIdentityValidator::instance();
     }
 

--- a/src/sip/PreferredIdentityValidator.h
+++ b/src/sip/PreferredIdentityValidator.h
@@ -39,6 +39,7 @@ class PreferredIdentityValidatorWrapper
 public:
     static PreferredIdentityValidator *create(QQmlEngine *, QJSEngine *)
     {
+        QQmlEngine::setObjectOwnership(&PreferredIdentityValidator::instance(), QQmlEngine::CppOwnership);
         return &PreferredIdentityValidator::instance();
     }
 

--- a/src/sip/SIPAccountManager.h
+++ b/src/sip/SIPAccountManager.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include <QQmlEngine>
 #include <QObject>
 #include <QtQml/qqml.h>
 #include <QtQml/qqmlregistration.h>
@@ -76,6 +78,7 @@ class SIPAccountManagerWrapper
 public:
     static SIPAccountManager *create(QQmlEngine *, QJSEngine *)
     {
+        QQmlEngine::setObjectOwnership(&SIPAccountManager::instance(), QQmlEngine::CppOwnership);
         return &SIPAccountManager::instance();
     }
 

--- a/src/sip/SIPCallManager.h
+++ b/src/sip/SIPCallManager.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include <QQmlEngine>
 #include <QObject>
 #include <QTimer>
 #include <QtQml/qqml.h>
@@ -173,7 +175,8 @@ class SIPCallManagerWrapper
     QML_SINGLETON
 
 public:
-    static SIPCallManager *create(QQmlEngine *, QJSEngine *) { return &SIPCallManager::instance(); }
+    static SIPCallManager *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&SIPCallManager::instance(), QQmlEngine::CppOwnership);
+        return &SIPCallManager::instance(); }
 
 private:
     SIPCallManagerWrapper() = default;

--- a/src/sip/SIPCallManager.h
+++ b/src/sip/SIPCallManager.h
@@ -175,8 +175,11 @@ class SIPCallManagerWrapper
     QML_SINGLETON
 
 public:
-    static SIPCallManager *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&SIPCallManager::instance(), QQmlEngine::CppOwnership);
-        return &SIPCallManager::instance(); }
+    static SIPCallManager *create(QQmlEngine *, QJSEngine *)
+    {
+        QQmlEngine::setObjectOwnership(&SIPCallManager::instance(), QQmlEngine::CppOwnership);
+        return &SIPCallManager::instance();
+    }
 
 private:
     SIPCallManagerWrapper() = default;

--- a/src/sip/SIPManager.h
+++ b/src/sip/SIPManager.h
@@ -125,8 +125,11 @@ class SIPManagerWrapper
     QML_SINGLETON
 
 public:
-    static SIPManager *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&SIPManager::instance(), QQmlEngine::CppOwnership);
-        return &SIPManager::instance(); }
+    static SIPManager *create(QQmlEngine *, QJSEngine *)
+    {
+        QQmlEngine::setObjectOwnership(&SIPManager::instance(), QQmlEngine::CppOwnership);
+        return &SIPManager::instance();
+    }
 
 private:
     SIPManagerWrapper() = default;

--- a/src/sip/SIPManager.h
+++ b/src/sip/SIPManager.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include <QQmlEngine>
 #include <QObject>
 #include <QtQml/qqml.h>
 #include <QtQml/qqmlregistration.h>
@@ -123,7 +125,8 @@ class SIPManagerWrapper
     QML_SINGLETON
 
 public:
-    static SIPManager *create(QQmlEngine *, QJSEngine *) { return &SIPManager::instance(); }
+    static SIPManager *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&SIPManager::instance(), QQmlEngine::CppOwnership);
+        return &SIPManager::instance(); }
 
 private:
     SIPManagerWrapper() = default;

--- a/src/sip/SIPTemplates.h
+++ b/src/sip/SIPTemplates.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include <QQmlEngine>
 #include <QObject>
 #include <QtQml/qqml.h>
 #include <QtQml/qqmlregistration.h>
@@ -44,7 +46,8 @@ class SIPTemplatesWrapper
     QML_SINGLETON
 
 public:
-    static SIPTemplates *create(QQmlEngine *, QJSEngine *) { return &SIPTemplates::instance(); }
+    static SIPTemplates *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&SIPTemplates::instance(), QQmlEngine::CppOwnership);
+        return &SIPTemplates::instance(); }
 
 private:
     SIPTemplatesWrapper() = default;

--- a/src/sip/SIPTemplates.h
+++ b/src/sip/SIPTemplates.h
@@ -46,8 +46,11 @@ class SIPTemplatesWrapper
     QML_SINGLETON
 
 public:
-    static SIPTemplates *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&SIPTemplates::instance(), QQmlEngine::CppOwnership);
-        return &SIPTemplates::instance(); }
+    static SIPTemplates *create(QQmlEngine *, QJSEngine *)
+    {
+        QQmlEngine::setObjectOwnership(&SIPTemplates::instance(), QQmlEngine::CppOwnership);
+        return &SIPTemplates::instance();
+    }
 
 private:
     SIPTemplatesWrapper() = default;

--- a/src/sip/TogglerManager.h
+++ b/src/sip/TogglerManager.h
@@ -54,8 +54,11 @@ class TogglerManagerWrapper
     QML_SINGLETON
 
 public:
-    static TogglerManager *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&TogglerManager::instance(), QQmlEngine::CppOwnership);
-        return &TogglerManager::instance(); }
+    static TogglerManager *create(QQmlEngine *, QJSEngine *)
+    {
+        QQmlEngine::setObjectOwnership(&TogglerManager::instance(), QQmlEngine::CppOwnership);
+        return &TogglerManager::instance();
+    }
 
 private:
     TogglerManagerWrapper() = default;

--- a/src/sip/TogglerManager.h
+++ b/src/sip/TogglerManager.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include <QQmlEngine>
 #include <QObject>
 #include <QtQml/qqml.h>
 #include <QtQml/qqmlregistration.h>
@@ -52,7 +54,8 @@ class TogglerManagerWrapper
     QML_SINGLETON
 
 public:
-    static TogglerManager *create(QQmlEngine *, QJSEngine *) { return &TogglerManager::instance(); }
+    static TogglerManager *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&TogglerManager::instance(), QQmlEngine::CppOwnership);
+        return &TogglerManager::instance(); }
 
 private:
     TogglerManagerWrapper() = default;

--- a/src/ui/ClipboardHelper.h
+++ b/src/ui/ClipboardHelper.h
@@ -38,6 +38,7 @@ class ClipboardHelperWrapper
 public:
     static ClipboardHelper *create(QQmlEngine *, QJSEngine *)
     {
+        QQmlEngine::setObjectOwnership(&ClipboardHelper::instance(), QQmlEngine::CppOwnership);
         return &ClipboardHelper::instance();
     }
 

--- a/src/ui/EnumTranslation.h
+++ b/src/ui/EnumTranslation.h
@@ -53,6 +53,7 @@ class EnumTranslationWrapper
 public:
     static EnumTranslation *create(QQmlEngine *, QJSEngine *)
     {
+        QQmlEngine::setObjectOwnership(&EnumTranslation::instance(), QQmlEngine::CppOwnership);
         return &EnumTranslation::instance();
     }
 

--- a/src/ui/FileHelper.h
+++ b/src/ui/FileHelper.h
@@ -45,7 +45,8 @@ class FileHelperWrapper
     QML_SINGLETON
 
 public:
-    static FileHelper *create(QQmlEngine *, QJSEngine *) { return &FileHelper::instance(); }
+    static FileHelper *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&FileHelper::instance(), QQmlEngine::CppOwnership);
+        return &FileHelper::instance(); }
 
 private:
     FileHelperWrapper() = default;

--- a/src/ui/FileHelper.h
+++ b/src/ui/FileHelper.h
@@ -45,8 +45,11 @@ class FileHelperWrapper
     QML_SINGLETON
 
 public:
-    static FileHelper *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&FileHelper::instance(), QQmlEngine::CppOwnership);
-        return &FileHelper::instance(); }
+    static FileHelper *create(QQmlEngine *, QJSEngine *)
+    {
+        QQmlEngine::setObjectOwnership(&FileHelper::instance(), QQmlEngine::CppOwnership);
+        return &FileHelper::instance();
+    }
 
 private:
     FileHelperWrapper() = default;

--- a/src/ui/SystemTrayMenu.h
+++ b/src/ui/SystemTrayMenu.h
@@ -106,8 +106,11 @@ class SystemTrayMenuWrapper
     QML_SINGLETON
 
 public:
-    static SystemTrayMenu *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&SystemTrayMenu::instance(), QQmlEngine::CppOwnership);
-        return &SystemTrayMenu::instance(); }
+    static SystemTrayMenu *create(QQmlEngine *, QJSEngine *)
+    {
+        QQmlEngine::setObjectOwnership(&SystemTrayMenu::instance(), QQmlEngine::CppOwnership);
+        return &SystemTrayMenu::instance();
+    }
 
 private:
     SystemTrayMenuWrapper() = default;

--- a/src/ui/SystemTrayMenu.h
+++ b/src/ui/SystemTrayMenu.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QQmlEngine>
+
 #include <QObject>
 #include <QSystemTrayIcon>
 #include <QMenu>
@@ -104,7 +106,8 @@ class SystemTrayMenuWrapper
     QML_SINGLETON
 
 public:
-    static SystemTrayMenu *create(QQmlEngine *, QJSEngine *) { return &SystemTrayMenu::instance(); }
+    static SystemTrayMenu *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&SystemTrayMenu::instance(), QQmlEngine::CppOwnership);
+        return &SystemTrayMenu::instance(); }
 
 private:
     SystemTrayMenuWrapper() = default;

--- a/src/ui/Theme.h
+++ b/src/ui/Theme.h
@@ -295,8 +295,11 @@ class ThemeWrapper
     QML_SINGLETON
 
 public:
-    static Theme *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&Theme::instance(), QQmlEngine::CppOwnership);
-        return &Theme::instance(); }
+    static Theme *create(QQmlEngine *, QJSEngine *)
+    {
+        QQmlEngine::setObjectOwnership(&Theme::instance(), QQmlEngine::CppOwnership);
+        return &Theme::instance();
+    }
 
 private:
     ThemeWrapper() = default;

--- a/src/ui/Theme.h
+++ b/src/ui/Theme.h
@@ -295,7 +295,8 @@ class ThemeWrapper
     QML_SINGLETON
 
 public:
-    static Theme *create(QQmlEngine *, QJSEngine *) { return &Theme::instance(); }
+    static Theme *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&Theme::instance(), QQmlEngine::CppOwnership);
+        return &Theme::instance(); }
 
 private:
     ThemeWrapper() = default;

--- a/src/ui/ViewHelper.h
+++ b/src/ui/ViewHelper.h
@@ -250,8 +250,11 @@ class ViewHelperWrapper
     QML_SINGLETON
 
 public:
-    static ViewHelper *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&ViewHelper::instance(), QQmlEngine::CppOwnership);
-        return &ViewHelper::instance(); }
+    static ViewHelper *create(QQmlEngine *, QJSEngine *)
+    {
+        QQmlEngine::setObjectOwnership(&ViewHelper::instance(), QQmlEngine::CppOwnership);
+        return &ViewHelper::instance();
+    }
 
 private:
     ViewHelperWrapper() = default;

--- a/src/ui/ViewHelper.h
+++ b/src/ui/ViewHelper.h
@@ -250,7 +250,8 @@ class ViewHelperWrapper
     QML_SINGLETON
 
 public:
-    static ViewHelper *create(QQmlEngine *, QJSEngine *) { return &ViewHelper::instance(); }
+    static ViewHelper *create(QQmlEngine *, QJSEngine *) { QQmlEngine::setObjectOwnership(&ViewHelper::instance(), QQmlEngine::CppOwnership);
+        return &ViewHelper::instance(); }
 
 private:
     ViewHelperWrapper() = default;


### PR DESCRIPTION
Set ownership for QML singletons to QML, so that a tear down doesn't crash.