### PR TITLE
fix: allow mwi without message count

### DIFF
--- a/src/sip/SIPAccount.cpp
+++ b/src/sip/SIPAccount.cpp
@@ -655,13 +655,13 @@ bool SIPAccount::callVoiceBox()
 {
     if (!m_voiceMailUri.isEmpty()) {
         qCDebug(lcSIPAccount) << "calling voice mail via" << m_voiceMailUri;
-        call(m_voiceMailUri);
+        SIPCallManager::instance().call(m_account, m_voiceMailUri);
         return true;
 
     } else if (!m_messageAccount.isEmpty()) {
         qCDebug(lcSIPAccount) << "calling voice mail via fallback from Message-Account"
                               << m_messageAccount;
-        call(m_messageAccount);
+        SIPCallManager::instance().call(m_account, m_messageAccount);
         return true;
     }
 

--- a/src/sip/SIPAccountManager.cpp
+++ b/src/sip/SIPAccountManager.cpp
@@ -107,6 +107,17 @@ uint SIPAccountManager::sipRegisterRetryInterval() const
     return 30;
 }
 
+bool SIPAccountManager::messagesWaiting() const
+{
+    for (const auto account : std::as_const(m_accounts)) {
+        if (account->messagesWaiting()) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 qint16 SIPAccountManager::newVoiceMessageCount() const
 {
     for (const auto account : std::as_const(m_accounts)) {

--- a/src/sip/SIPAccountManager.h
+++ b/src/sip/SIPAccountManager.h
@@ -14,6 +14,7 @@ class SIPAccountManager : public QObject
 
     Q_PROPERTY(bool sipRegistered READ sipRegistered NOTIFY sipRegisteredChanged FINAL)
     Q_PROPERTY(uint sipRegisterRetryInterval READ sipRegisterRetryInterval CONSTANT FINAL)
+    Q_PROPERTY(bool messagesWaiting READ messagesWaiting NOTIFY voiceMessagesWaitingChanged FINAL)
     Q_PROPERTY(qint16 newVoiceMessageCount READ newVoiceMessageCount NOTIFY
                        voiceMessagesWaitingChanged FINAL)
     Q_PROPERTY(qint16 oldVoiceMessageCount READ oldVoiceMessageCount NOTIFY
@@ -33,6 +34,8 @@ public:
 
     bool sipRegistered() const { return m_sipRegistered; }
     uint sipRegisterRetryInterval() const;
+
+    bool messagesWaiting() const;
     qint16 newVoiceMessageCount() const;
     qint16 oldVoiceMessageCount() const;
 

--- a/src/ui/components/controls/VoiceMailField.qml
+++ b/src/ui/components/controls/VoiceMailField.qml
@@ -20,7 +20,7 @@ Item {
         }
     }
 
-    property int totalVoicemailCount: control.messagesWaitingWithUnknownCount ? 1 : (control.realVoicemailCount)
+    property int totalVoicemailCount: control.messagesWaitingWithUnknownCount ? 1 : control.realVoicemailCount
 
     property int realVoicemailCount: control.newVoicemailCount + control.oldVoicemailCount
     property int newVoicemailCount: SIPAccountManager.newVoiceMessageCount

--- a/src/ui/components/controls/VoiceMailField.qml
+++ b/src/ui/components/controls/VoiceMailField.qml
@@ -11,7 +11,7 @@ Item {
     implicitWidth: voicemailRow.width
     implicitHeight: 30
 
-    // Only display the icon if the widget heading is not long enough
+    // Only display the label if the widget heading is not long enough
     property double maxWidth: 0
     Connections {
         target: parent

--- a/src/ui/components/controls/VoiceMailField.qml
+++ b/src/ui/components/controls/VoiceMailField.qml
@@ -11,14 +11,25 @@ Item {
     implicitWidth: voicemailRow.width
     implicitHeight: 30
 
-    property int totalVoicemailCount: control.newVoicemailCount + control.oldVoicemailCount
+    // Only display the icon if the widget heading is not long enough
+    property double maxWidth: 0
+    Connections {
+        target: parent
+        function onWidthChanged() {
+            maxWidth = parent.width / 4
+        }
+    }
+
+    property int totalVoicemailCount: control.messagesWaitingWithUnknownCount ? 1 : (control.realVoicemailCount)
+
+    property int realVoicemailCount: control.newVoicemailCount + control.oldVoicemailCount
     property int newVoicemailCount: SIPAccountManager.newVoiceMessageCount
     property int oldVoicemailCount: SIPAccountManager.oldVoiceMessageCount
 
+    property bool messagesWaitingWithUnknownCount: control.messagesWaiting && control.realVoicemailCount === 0
     property bool messagesWaiting: SIPAccountManager.messagesWaiting
-    property bool messagesWaitingWithUnknownCount: control.messagesWaiting && control.totalVoicemailCount === 0
 
-    property bool hasVoicemail: control.totalVoicemailCount > 0 || control.messagesWaiting
+    property bool hasVoicemail: control.realVoicemailCount > 0 || control.messagesWaiting
     property bool hasNewVoicemail: control.newVoicemailCount > 0 || control.messagesWaitingWithUnknownCount
 
     Accessible.role: Accessible.Button
@@ -65,6 +76,7 @@ Item {
             font.weight: Font.Medium
             elide: Text.ElideRight
             color: Theme.secondaryTextColor
+            visible: (voicemailIcon.implicitWidth + voicemailCount.implicitWidth) < control.maxWidth
 
             Accessible.ignored: true
         }

--- a/src/ui/components/controls/VoiceMailField.qml
+++ b/src/ui/components/controls/VoiceMailField.qml
@@ -15,9 +15,6 @@ Item {
     property int newVoicemailCount: SIPAccountManager.newVoiceMessageCount
     property int oldVoicemailCount: SIPAccountManager.oldVoiceMessageCount
 
-    property bool hasVoicemail: control.totalVoicemailCount > 0
-    property bool hasNewVoicemail: control.newVoicemailCount > 0
-
     property bool messagesWaiting: SIPAccountManager.messagesWaiting
     property bool messagesWaitingWithUnknownCount: control.messagesWaiting && control.totalVoicemailCount === 0
 

--- a/src/ui/components/controls/VoiceMailField.qml
+++ b/src/ui/components/controls/VoiceMailField.qml
@@ -18,6 +18,12 @@ Item {
     property bool hasVoicemail: control.totalVoicemailCount > 0
     property bool hasNewVoicemail: control.newVoicemailCount > 0
 
+    property bool messagesWaiting: SIPAccountManager.messagesWaiting
+    property bool messagesWaitingWithUnknownCount: control.messagesWaiting && control.totalVoicemailCount === 0
+
+    property bool hasVoicemail: control.totalVoicemailCount > 0 || control.messagesWaiting
+    property bool hasNewVoicemail: control.newVoicemailCount > 0 || control.messagesWaitingWithUnknownCount
+
     Accessible.role: Accessible.Button
     Accessible.name: qsTr("Listen to voicemail")
     Accessible.onPressAction: () => SIPAccountManager.callVoiceBox("account0")
@@ -53,9 +59,11 @@ Item {
 
         Label {
             id: voicemailCount
-            text: control.hasNewVoicemail
-                  ? qsTr("%n new voice mail(s)", "", control.newVoicemailCount)
-                  : qsTr("%n old voice mail(s)", "", control.oldVoicemailCount)
+            text: control.messagesWaitingWithUnknownCount
+                  ? qsTr("New voice mail")
+                  : control.hasNewVoicemail
+                    ? qsTr("%n new voice mail(s)", "", control.newVoicemailCount)
+                    : qsTr("%n old voice mail(s)", "", control.oldVoicemailCount)
             font.pixelSize: 16
             font.weight: Font.Medium
             elide: Text.ElideRight


### PR DESCRIPTION
Some implementations (i.e. Cisco Call Manager) don't send any information about the waiting message count - only that there are some waiting.