### PR TITLE
fix: mini fixes

### DIFF
--- a/src/helper/TextFormatHelper.cpp
+++ b/src/helper/TextFormatHelper.cpp
@@ -1,5 +1,8 @@
 #include "TextFormatHelper.h"
 
+#include <cmath>
+#include <algorithm>
+
 TextFormatHelper::TextFormatHelper(QObject *parent) : QObject{ parent } { }
 
 QString TextFormatHelper::formatFileSize(qint64 byteSize) const

--- a/src/media/AudioManager.cpp
+++ b/src/media/AudioManager.cpp
@@ -78,10 +78,10 @@ AudioProcessor *AudioManager::audioProcessor()
     }
 
     unsigned features = 0;
-    if (m_settings.value("media/anc", true).toBool()) {
+    if (m_settings.value("media/anc", false).toBool()) {
         features |= AudioProcessor::NoiseSuppression;
     }
-    if (m_settings.value("media/aec", true).toBool()) {
+    if (m_settings.value("media/aec", false).toBool()) {
         features |= AudioProcessor::EchoCancellation;
     }
     if (m_settings.value("media/agc", true).toBool()) {

--- a/src/usb/ReportDescriptorParser.cpp
+++ b/src/usb/ReportDescriptorParser.cpp
@@ -5,32 +5,19 @@
 #include "ReportDescriptorParser.h"
 
 #include "hid/rdf/descriptor_view.hpp"
-#include "hid/rdf/parser.hpp"
 
 Q_LOGGING_CATEGORY(lcParser, "gonnect.usb.parser")
 
 ReportDescriptorParser::ReportDescriptorParser(QObject *parent) : QObject(parent) { }
 
-using desc_view = hid::rdf::ce_descriptor_view;
-
 typedef hid::rdf::global::tag GlobalTag;
 typedef hid::rdf::main::tag MainTag;
 typedef hid::rdf::local::tag LocalTag;
-
-class Parser : public hid::rdf::parser<desc_view::iterator>
-{
-public:
-    constexpr Parser(const desc_view &desc_view) : hid::rdf::parser<desc_view::iterator>()
-    {
-        hid::rdf::parser<desc_view::iterator>::parse_items(desc_view);
-    }
-};
 
 std::shared_ptr<ApplicationCollection> ReportDescriptorParser::parse(const QByteArray &data)
 {
     const hid::rdf::descriptor_view descView(
             reinterpret_cast<const unsigned char *>(data.constData()), data.size());
-    const Parser p(descView);
 
     static const QList<hid::rdf::main::tag> usageTypeTags = { MainTag::INPUT, MainTag::OUTPUT,
                                                               MainTag::FEATURE };
@@ -191,7 +178,6 @@ ReportDescriptorParser::parseTeamsReportIDs(const QByteArray &data)
     // even need that, but as it can be done by linear parsing, just do it...
     const hid::rdf::descriptor_view descView(
             reinterpret_cast<const unsigned char *>(data.constData()), data.size());
-    const Parser p(descView);
 
     bool inTeamsPage = false;
     quint8 uCDisplayCollectionLevel = 0xFF;

--- a/src/usb/USBDevices.cpp
+++ b/src/usb/USBDevices.cpp
@@ -147,7 +147,7 @@ int USBDevices::hotplugHandler(libusb_context *, libusb_device *device, libusb_h
 void USBDevices::refresh()
 {
     QMutexLocker lock(&s_enumerateMutex);
-    QString lastPath;
+    QSet<QString> handledPaths;
     auto &busylightDeviceManager = BusylightDeviceManager::instance();
 
     // Collect devices previously in use
@@ -191,17 +191,21 @@ void USBDevices::refresh()
     for (; deviceInfo; deviceInfo = deviceInfo->next) {
 
         QString path = deviceInfo->path;
-        if (previousPaths.contains(path) || path == lastPath) {
+        if (previousPaths.contains(path) || handledPaths.contains(path)) {
             continue;
         }
 
-        lastPath = path;
-
-        if (!busylightDeviceManager.createBusylightDevice(*deviceInfo)) {
+        bool created = busylightDeviceManager.createBusylightDevice(*deviceInfo);
+        if (!created) {
             HeadsetDevice *hd = parseReportDescriptor(deviceInfo);
             if (hd) {
                 m_headsetDevices.push_back(hd);
+                created = true;
             }
+        }
+
+        if (created) {
+            handledPaths.insert(path);
         }
     }
 


### PR DESCRIPTION
Relax hid device parsing and don't insist in having the telephony report in the first place. Fix a crash and remove unused parser.