### PR TITLE
feat(carddav): strip base numbers

### DIFF
--- a/docs/modules/ROOT/examples/sample.conf
+++ b/docs/modules/ROOT/examples/sample.conf
@@ -713,6 +713,12 @@ userUri=sip:user@example.org
 ## (optional, default: 0)
 #prio=50
 
+## A phone number prefix which is stripped from each phone number read from the CardDAV source.
+## This is useful to strip a company's own number and just take the "internal number".
+## Example: Given baseNumber="+492933911", the number "+492933911678" will appear as "678" in the address book.
+## (optional)
+#baseNumber="+492933911"
+
 ## The host is the main host address of the remote server, without any port, protocol or path data.
 # host=cloud.mycompany.com
 

--- a/src/contacts/carddav/CardDAVAddressBookFeeder.cpp
+++ b/src/contacts/carddav/CardDAVAddressBookFeeder.cpp
@@ -134,6 +134,14 @@ void CardDAVAddressBookFeeder::processVcard(QByteArray data, const QString &uuid
         return;
     }
 
+    auto stripBaseNumber = [this](QString num) {
+        const auto baseNumber = m_config.baseNumber;
+        if (num.startsWith(baseNumber)) {
+            num = num.sliced(baseNumber.size());
+        }
+        return num;
+    };
+
     // Process vcard
     std::istringstream stringStream(data.toStdString());
     TextReader reader(stringStream);
@@ -162,7 +170,8 @@ void CardDAVAddressBookFeeder::processVcard(QByteArray data, const QString &uuid
                 email = QString::fromStdString(prop.getValue());
             } else if (propName == "TEL") {
                 phoneNumbers.append({ Contact::NumberType::Unknown,
-                                      QString::fromStdString(prop.getValue()), false });
+                                      stripBaseNumber(QString::fromStdString(prop.getValue())),
+                                      false });
             } else if (propName == "PHOTO") {
 
                 auto propParams = prop.params();
@@ -404,9 +413,12 @@ void CardDAVAddressBookFeeder::process()
         m_priority = 0;
     }
 
-    m_config = { settings.value("host", "").toString(), settings.value("path", "").toString(),
+    m_config = { settings.value("baseNumber", "").toString(),
+                 settings.value("host", "").toString(),
+                 settings.value("path", "").toString(),
                  settings.value("user", "").toString(),
-                 settings.value("port", useSSL ? 443 : 80).toInt(), useSSL };
+                 settings.value("port", useSSL ? 443 : 80).toInt(),
+                 useSSL };
 
     init();
     feedAddressBook();

--- a/src/contacts/carddav/CardDAVAddressBookFeederConfig.h
+++ b/src/contacts/carddav/CardDAVAddressBookFeederConfig.h
@@ -4,6 +4,7 @@
 
 struct CardDAVAddressBookFeederConfig
 {
+    QString baseNumber;
     QString host;
     QString path;
     QString user;


### PR DESCRIPTION
Similar to LDAP contact sources, it's now possible to specify a `baseNumber` in CardDAV contact sources so that it can be stripped in order to only retain the internal number. 