### PR TITLE
fix: fixed crash because of empty stamp in jtisi message

### DIFF
--- a/src/ui/JitsiConnector.cpp
+++ b/src/ui/JitsiConnector.cpp
@@ -461,7 +461,7 @@ api.addListener("errorOccurred", data => {
 })
 
 api.addListener("incomingMessage", data => {
-    const stamp = data.hasOwnProperty("stamp") ? data.stamp : new Date()
+    const stamp = data.stamp ?? new Date()
     jitsiConn.addIncomingMessage(data.from, data.nick, data.message, stamp, data.privateMessage)
 })
 


### PR DESCRIPTION
Jitsi Meet has changed the format of the data JSON for `incomingMessage` such, that `stamp` is now always there, even if `null`.