### PR TITLE
fix: initial network state

### DIFF
--- a/appversion.cpp.in
+++ b/appversion.cpp.in
@@ -3,3 +3,7 @@
 std::string getVersion() {
     return "@VERSION@";
 }
+
+std::string getCommitHash() {
+    return "@APP_GIT_HASH@";
+}

--- a/appversion.h
+++ b/appversion.h
@@ -2,3 +2,4 @@
 #include <string>
 
 std::string getVersion();
+std::string getCommitHash();

--- a/cmake/Versioning.cmake
+++ b/cmake/Versioning.cmake
@@ -18,6 +18,14 @@ if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
         string(REGEX MATCH "v([0-9a-z.+-]*)" _ ${VERSION})
         set(VERSION "${CMAKE_MATCH_1}")
     endif()
+
+    execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+                RESULT_VARIABLE GIT_RESULT
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                OUTPUT_VARIABLE GIT_HASH)
+
+    set(APP_GIT_HASH ${GIT_HASH})
 endif()
 
 # Fall back to project version

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -52,7 +52,8 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
     if (commitId.isEmpty()) {
         qCCritical(lcApplication) << "Constructing debug app, version" << getVersion();
     } else {
-        qCCritical(lcApplication).nospace() << "Constructing app, version " << getVersion() << " [" << commitId << "]";
+        qCCritical(lcApplication).nospace()
+                << "Constructing app, version " << getVersion() << " [" << commitId << "]";
     }
 
     connect(this, &Application::aboutToQuit, this, &Application::shutdown);

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -5,7 +5,6 @@
 #include "NotificationManager.h"
 #include "appversion.h"
 #include "SIPManager.h"
-#include "SIPCallManager.h"
 #include "SystemTrayMenu.h"
 #include "AddressBookManager.h"
 #include "USBDevices.h"
@@ -49,7 +48,13 @@ int Application::s_sigtermFd[2];
 
 Application::Application(int &argc, char **argv) : QApplication(argc, argv)
 {
-    qCCritical(lcApplication) << "Constructing app, version" << getVersion();
+    QString commitId = QString::fromStdString(getCommitHash());
+    if (commitId.isEmpty()) {
+        qCCritical(lcApplication) << "Constructing debug app, version" << getVersion();
+    } else {
+        qCCritical(lcApplication).nospace() << "Constructing app, version " << getVersion() << " [" << commitId << "]";
+    }
+
     connect(this, &Application::aboutToQuit, this, &Application::shutdown);
 
     setApplicationName("GOnnect");

--- a/src/platform/NetworkHelper.cpp
+++ b/src/platform/NetworkHelper.cpp
@@ -7,6 +7,7 @@
 #include <QJsonDocument>
 #include <QtConcurrent>
 #include <QNetworkAccessManager>
+#include <QNetworkInterface>
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QEventLoop>
@@ -189,6 +190,22 @@ QStringList NetworkHelper::nameservers() const
     result.append(parseResolvConf("/etc/resolv.conf"));
     result.append(parseResolvConf("/run/systemd/resolve/resolv.conf"));
     result.removeDuplicates();
+
+    return result;
+}
+
+QSet<QString> NetworkHelper::localAddresses() const
+{
+    QSet<QString> result;
+
+    const auto addresses = QNetworkInterface::allAddresses();
+    for (const QHostAddress &address : std::as_const(addresses)) {
+        if (address.isLoopback() || address.isLinkLocal()) {
+            continue;
+        }
+
+        result.insert(address.toString());
+    }
 
     return result;
 }

--- a/src/platform/NetworkHelper.h
+++ b/src/platform/NetworkHelper.h
@@ -3,6 +3,7 @@
 #include <QNetworkInformation>
 #include <QFuture>
 #include <QJsonDocument>
+#include <QSet>
 
 class NetworkHelper : public QObject
 {
@@ -22,6 +23,7 @@ public:
     virtual QFuture<bool> isReachable(const QUrl &url);
 
     virtual QStringList nameservers() const;
+    virtual QSet<QString> localAddresses() const;
 
     ~NetworkHelper() = default;
 

--- a/src/sip/SIPManager.cpp
+++ b/src/sip/SIPManager.cpp
@@ -487,7 +487,20 @@ void SIPManager::handleNetworkChanged()
         return;
     }
 
+    const auto currentAddresses = NetworkHelper::instance().localAddresses();
+
+    // Capture initial network state
+    if (m_lastLocalAddresses.isEmpty()) {
+        m_lastLocalAddresses = currentAddresses;
+        return;
+    }
+
+    if (currentAddresses == m_lastLocalAddresses) {
+        return;
+    }
+
     qCDebug(lcSIPManager) << "network changed - scheduling SIP recovery";
+    m_lastLocalAddresses = currentAddresses;
     m_networkRecoveryAttempts = 0;
     m_registrationCheckTimer.stop();
     m_networkRecoveryTimer.start(1s);

--- a/src/sip/SIPManager.h
+++ b/src/sip/SIPManager.h
@@ -101,6 +101,7 @@ private:
     QTimer m_registrationCheckTimer;
     int m_networkRecoveryAttempts = 0;
     static constexpr int s_maxNetworkRecoveryAttempts = 6;
+    QSet<QString> m_lastLocalAddresses;
 
     std::unique_ptr<AppSettings> m_settings = nullptr;
 


### PR DESCRIPTION
Avoid toggling of initial network state by memorising the available local addresses at first.