### PR TITLE
chore: move to caching settings

### DIFF
--- a/src/AppSettings.h
+++ b/src/AppSettings.h
@@ -3,6 +3,8 @@
 #include <QStandardPaths>
 #include <QLibraryInfo>
 
+#include "ReadOnlyConfdSettings.h"
+
 class AppSettings : public QSettings
 {
     Q_OBJECT
@@ -14,5 +16,31 @@ public:
                     QSettings::IniFormat, parent)
     {
     }
+
     ~AppSettings() = default;
+
+    void setValue(QAnyStringView key, const QVariant &value)
+    {
+        QSettings::setValue(key, value);
+        invalidateConfdCache();
+    }
+
+    void remove(QAnyStringView key)
+    {
+        QSettings::remove(key);
+        invalidateConfdCache();
+    }
+
+    void clear()
+    {
+        QSettings::clear();
+        invalidateConfdCache();
+    }
+
+private:
+    void invalidateConfdCache()
+    {
+        sync();
+        ReadOnlyConfdSettings::invalidateCache();
+    }
 };

--- a/src/ReadOnlyConfdSettings.cpp
+++ b/src/ReadOnlyConfdSettings.cpp
@@ -3,6 +3,7 @@
 #include <QRegularExpression>
 #include <QLoggingCategory>
 #include <QCryptographicHash>
+#include <QMutex>
 
 #ifdef Q_OS_WINDOWS
 static constexpr const char *NULL_DEVICE_NAME = "nul";
@@ -16,15 +17,9 @@ static constexpr const char *NULL_DEVICE_NAME = "/dev/null";
 
 Q_LOGGING_CATEGORY(lcReadOnlySettings, "gonnect.app.settings")
 
-ReadOnlyConfdSettings::ReadOnlyConfdSettings(QObject *parent)
-    : QSettings(NULL_DEVICE_NAME, QSettings::IniFormat, parent)
-{
-    setFallbacksEnabled(false);
-    readConfd();
-}
-
+namespace {
 #ifdef Q_OS_LINUX
-QString ReadOnlyConfdSettings::gidToName(gid_t gid)
+QString gidToName(gid_t gid)
 {
     struct group *g;
     g = getgrgid(gid);
@@ -36,7 +31,7 @@ QString ReadOnlyConfdSettings::gidToName(gid_t gid)
     return g->gr_name;
 }
 
-QStringList ReadOnlyConfdSettings::getUserGroups()
+QStringList getUserGroups()
 {
     QStringList res;
 
@@ -58,76 +53,7 @@ QStringList ReadOnlyConfdSettings::getUserGroups()
 };
 #endif
 
-void ReadOnlyConfdSettings::readConfd()
-{
-    static const QRegularExpression configFileName(R"(\d+-[a-zA-Z0-9_-]+\.conf$)");
-
-    // Collect ini files
-    QStringList entries;
-
-    if (qEnvironmentVariable("container") == "flatpak") {
-        const auto fpBaseDir = QDir("/app/etc/gonnect");
-        const auto files = fpBaseDir.entryList(QDir::Files | QDir::Readable, QDir::Name);
-        for (const auto &entry : files) {
-            entries += fpBaseDir.absoluteFilePath(entry);
-        }
-    }
-
-    const auto baseDir =
-            QDir(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + "/gonnect/");
-    const auto files = baseDir.entryList(QDir::Files | QDir::Readable, QDir::Name);
-    for (const auto &entry : files) {
-        entries += baseDir.absoluteFilePath(entry);
-    }
-
-#ifdef Q_OS_LINUX
-    // Filter scope and replace %ENV[variablename]% and %CONF[config/key]% placeholders
-    const auto groupList = getUserGroups();
-#else
-    const auto groupList = QStringList();
-#endif
-
-    for (auto &entry : std::as_const(entries)) {
-        if (configFileName.match(entry).hasMatch()) {
-
-            const QSettings tmpSettings(entry, QSettings::IniFormat);
-
-            // Check if the configuration snippet is relevant to us
-            const QString onlyForGroup = tmpSettings.value("scope/group").toString();
-            if (!onlyForGroup.isEmpty() && !groupList.contains(onlyForGroup)) {
-                continue;
-            }
-
-            // Copy over all keys, overwriting older values if desired
-            const QStringList keys = tmpSettings.allKeys();
-            for (auto &key : std::as_const(keys)) {
-                if (key.startsWith("scope/")) {
-                    continue;
-                }
-
-                QVariant settingsValue = tmpSettings.value(key);
-
-                if (settingsValue.userType() == QMetaType::QStringList) {
-                    QStringList newList;
-                    const QStringList strings = settingsValue.toStringList();
-                    newList.reserve(strings.length());
-                    std::ranges::transform(
-                            strings, std::back_inserter(newList),
-                            [this](const QString &s) { return replacePlaceholders(s); });
-
-                    setValue(key, newList);
-
-                } else if (settingsValue.userType() == QMetaType::QString) {
-                    setValue(key, replacePlaceholders(settingsValue.toString()));
-                } else {
-                    setValue(key, settingsValue);
-                }
-            }
-        }
-    }
-}
-
-QString ReadOnlyConfdSettings::replacePlaceholders(const QString &settingsStringValue) const
+QString replacePlaceholders(const QString &settingsStringValue, const QVariantMap &resolved)
 {
     static const QRegularExpression envPlaceholder(R"(%ENV\[([a-zA-Z][A-Za-z0-9_]*)\]%)");
     static const QRegularExpression cfgPlaceholder(R"(%CFG\[([A-Za-z0-9_/.\-]+)\]%)");
@@ -154,10 +80,140 @@ QString ReadOnlyConfdSettings::replacePlaceholders(const QString &settingsString
     for (qsizetype i = cfgList.size() - 1; i >= 0; --i) {
         const auto cfgMatch = cfgList.at(i);
         str.replace(cfgMatch.capturedStart(0), cfgMatch.capturedLength(0),
-                    value(cfgMatch.captured(1)).toString());
+                    resolved.value(cfgMatch.captured(1)).toString());
     }
 
     return str;
+}
+
+QStringList scanConfd()
+{
+    static const QRegularExpression configFileName(R"(\d+-[a-zA-Z0-9_-]+\.conf$)");
+
+    QStringList dirs;
+    if (qEnvironmentVariable("container") == "flatpak") {
+        dirs += QStringLiteral("/app/etc/gonnect");
+    }
+
+    dirs += QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + "/gonnect";
+
+    QStringList entries;
+
+    for (const auto &dirPath : std::as_const(dirs)) {
+        const QDir dir(dirPath);
+        const auto files = dir.entryList(QDir::Files | QDir::Readable, QDir::Name);
+
+        for (const auto &file : files) {
+            const auto path = dir.absoluteFilePath(file);
+            if (configFileName.match(path).hasMatch()) {
+                entries += path;
+            }
+        }
+    }
+
+    return entries;
+}
+
+QVariantMap buildEntries(const QStringList &files)
+{
+#ifdef Q_OS_LINUX
+    const auto groupList = getUserGroups();
+#else
+    const auto groupList = getUserGroups();
+#endif
+
+    QVariantMap resolved;
+    for (const auto &file : files) {
+        const QSettings tmpSettings(file, QSettings::IniFormat);
+
+        // Check if the configuration snippet is relevant to us
+        const QString onlyForGroup = tmpSettings.value("scope/group").toString();
+        if (!onlyForGroup.isEmpty() && !groupList.contains(onlyForGroup)) {
+            continue;
+        }
+
+        // Copy over all keys, overwriting older values if desired
+        const QStringList keys = tmpSettings.allKeys();
+        for (const auto &key : keys) {
+            if (key.startsWith("scope/")) {
+                continue;
+            }
+
+            const QVariant settingsValue = tmpSettings.value(key);
+
+            if (settingsValue.userType() == QMetaType::QStringList) {
+                QStringList newList;
+                const QStringList strings = settingsValue.toStringList();
+                newList.reserve(strings.length());
+                std::ranges::transform(
+                        strings, std::back_inserter(newList),
+                        [&resolved](const QString &s) { return replacePlaceholders(s, resolved); });
+
+                resolved.insert(key, newList);
+
+            } else if (settingsValue.userType() == QMetaType::QString) {
+                resolved.insert(key, replacePlaceholders(settingsValue.toString(), resolved));
+            } else {
+                resolved.insert(key, settingsValue);
+            }
+        }
+    }
+
+    return resolved;
+}
+
+struct ConfdCache
+{
+    QMutex mutex;
+    bool valid = false;
+    QVariantMap entries;
+};
+
+Q_GLOBAL_STATIC(ConfdCache, confdCache)
+
+QVariantMap mergedEntries()
+{
+    auto *cache = confdCache();
+    if (!cache) {
+        return {};
+    }
+
+    const QMutexLocker locker(&cache->mutex);
+
+    if (!cache->valid) {
+        const auto files = scanConfd();
+        cache->entries = buildEntries(files);
+        cache->valid = true;
+    }
+
+    return cache->entries;
+}
+
+} // namespace
+
+ReadOnlyConfdSettings::ReadOnlyConfdSettings(QObject *parent)
+    : QSettings(NULL_DEVICE_NAME, QSettings::IniFormat, parent)
+{
+    setFallbacksEnabled(false);
+    readConfd();
+}
+
+void ReadOnlyConfdSettings::readConfd()
+{
+    const QVariantMap entries = mergedEntries();
+
+    for (auto it = entries.cbegin(), end = entries.cend(); it != end; ++it) {
+        setValue(it.key(), it.value());
+    }
+}
+
+void ReadOnlyConfdSettings::invalidateCache()
+{
+    if (auto *cache = confdCache()) {
+        const QMutexLocker locker(&cache->mutex);
+        cache->valid = false;
+        cache->entries.clear();
+    }
 }
 
 QString ReadOnlyConfdSettings::hashForSettingsGroup(const QString &group)

--- a/src/ReadOnlyConfdSettings.cpp
+++ b/src/ReadOnlyConfdSettings.cpp
@@ -119,7 +119,7 @@ QVariantMap buildEntries(const QStringList &files)
 #ifdef Q_OS_LINUX
     const auto groupList = getUserGroups();
 #else
-    const auto groupList = getUserGroups();
+    const auto groupList = QStringList();
 #endif
 
     QVariantMap resolved;

--- a/src/ReadOnlyConfdSettings.h
+++ b/src/ReadOnlyConfdSettings.h
@@ -15,6 +15,4 @@ public:
 
 private:
     void readConfd();
-
-    QString replacePlaceholders(const QString &value) const;
 };

--- a/src/ReadOnlyConfdSettings.h
+++ b/src/ReadOnlyConfdSettings.h
@@ -11,12 +11,9 @@ public:
 
     QString hashForSettingsGroup(const QString &group);
 
-private:
-#ifdef Q_OS_LINUX
-    QString gidToName(gid_t gid);
-    QStringList getUserGroups();
-#endif
+    static void invalidateCache();
 
+private:
     void readConfd();
 
     QString replacePlaceholders(const QString &value) const;


### PR DESCRIPTION
There are 50+ locations where we create a new object and load the config from disc over and over again. Lets change this to a caching approach.